### PR TITLE
Removed redundant variable initialization

### DIFF
--- a/src/Scim/SimpleIdServer.Scim/Helpers/AttributeReferenceEnricher.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/AttributeReferenceEnricher.cs
@@ -28,7 +28,6 @@ namespace SimpleIdServer.Scim.Helpers
             }
 
             var ids = representationLst.Select(r => r.Id);
-            var schemas = representationLst.First().Schemas;
             foreach (var attributeMapping in attributeMappingLst)
             {
                 var targetRepresentations = await _scimRepresentationQueryRepository.FindSCIMRepresentationByAttributes(attributeMapping.TargetAttributeId, ids, attributeMapping.TargetResourceType);


### PR DESCRIPTION
The declaration of the variable and its assignment caused the function to error when the search result had returned no errors. 
IE: representationLst contains zero elements
The code seems like it was left over from previous work