### PR TITLE
Update SCIMExpressionLinqExtensions.cs - small fix on ParseBoolean method

### DIFF
--- a/src/Scim/SimpleIdServer.Scim/Persistence/SCIMExpressionLinqExtensions.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/SCIMExpressionLinqExtensions.cs
@@ -563,7 +563,7 @@ namespace SimpleIdServer.Scim.Extensions
         private static bool ParseBoolean(string str)
         {
             bool result;
-            if (!bool.TryParse(str, out result))
+            if (bool.TryParse(str, out result))
             {
                 return result;
             }


### PR DESCRIPTION
Small fix on ParseBoolean method - SCIMExpressionLinqExtensions.cs