### PR TITLE
Add ExcludedAttributes to SearchSCIMRepresentationsParameter

### DIFF
--- a/src/Scim/SimpleIdServer.Scim/Api/BaseApiController.cs
+++ b/src/Scim/SimpleIdServer.Scim/Api/BaseApiController.cs
@@ -176,7 +176,7 @@ namespace SimpleIdServer.Scim.Api
                     return this.BuildError(HttpStatusCode.BadRequest, Global.StartIndexMustBeSuperiorOrEqualTo1);
                 }
 
-                var result = await _scimRepresentationQueryRepository.FindSCIMRepresentations(new SearchSCIMRepresentationsParameter(_resourceType, searchRequest.StartIndex, searchRequest.Count.Value, sortByFilter, searchRequest.SortOrder, SCIMFilterParser.Parse(searchRequest.Filter, schemas), searchRequest.Attributes));
+                var result = await _scimRepresentationQueryRepository.FindSCIMRepresentations(new SearchSCIMRepresentationsParameter(_resourceType, searchRequest.StartIndex, searchRequest.Count.Value, sortByFilter, searchRequest.SortOrder, SCIMFilterParser.Parse(searchRequest.Filter, schemas), searchRequest.Attributes, searchRequest.ExcludedAttributes));
                 var jObj = new JObject
                 {
                     { SCIMConstants.StandardSCIMRepresentationAttributes.Schemas, new JArray(new [] { SCIMConstants.StandardSchemas.ListResponseSchemas.Id } ) },

--- a/src/Scim/SimpleIdServer.Scim/Persistence/SearchSCIMRepresentationsParameter.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/SearchSCIMRepresentationsParameter.cs
@@ -8,7 +8,7 @@ namespace SimpleIdServer.Scim.Persistence
 {
     public class SearchSCIMRepresentationsParameter
     {
-        public SearchSCIMRepresentationsParameter(string resourceType, int startIndex, int count, SCIMExpression sortBy, SearchSCIMRepresentationOrders? sortOrder = null, SCIMExpression filter = null, IEnumerable<string> attributes = null)
+        public SearchSCIMRepresentationsParameter(string resourceType, int startIndex, int count, SCIMExpression sortBy, SearchSCIMRepresentationOrders? sortOrder = null, SCIMExpression filter = null, IEnumerable<string> attributes = null, IEnumerable<string> excludedAttributes = null)
         {
             ResourceType = resourceType;
             StartIndex = startIndex;
@@ -17,6 +17,7 @@ namespace SimpleIdServer.Scim.Persistence
             SortOrder = sortOrder;
             Filter = filter;
             Attributes = attributes;
+            ExcludedAttributes = excludedAttributes;
         }
 
         public IEnumerable<string> Attributes { get; set; }
@@ -25,6 +26,7 @@ namespace SimpleIdServer.Scim.Persistence
         public int Count { get; set; }
         public SCIMExpression SortBy { get; set; }
         public SearchSCIMRepresentationOrders? SortOrder { get; set; }
-        public SCIMExpression Filter { get; set; } 
+        public SCIMExpression Filter { get; set; }
+        public IEnumerable<string> ExcludedAttributes { get; set; }
     }
 }


### PR DESCRIPTION
Attributes are already sent to repository level so I added ExcludedAttributes to SearchSCIMRepresentationsParameter too. In the future we can directly get the needed attributes in the repository so it's gonna be a lot faster. For example, if you want to get the group without members or user information without groups that is part of, it's faster not to get few thousands groups (even if only ids) than get all and remove it later when you build the response.