### PR TITLE
fix the canonicalValue ignore case issue

### DIFF
--- a/src/Scim/SimpleIdServer.Scim/Helpers/SCIMRepresentationHelper.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/SCIMRepresentationHelper.cs
@@ -220,7 +220,13 @@ namespace SimpleIdServer.Scim.Helpers
                         break;
                     case SCIMSchemaAttributeTypes.STRING:
                         var strs = jArr.Select(j => j.ToString()).ToList();
-                        if (schemaAttribute.CanonicalValues != null && schemaAttribute.CanonicalValues.Any() && !ignoreUnsupportedCanonicalValues && !strs.All(_ => schemaAttribute.CanonicalValues.Contains(_)))
+                        if (schemaAttribute.CanonicalValues != null
+                            && schemaAttribute.CanonicalValues.Any()
+                            && !ignoreUnsupportedCanonicalValues
+                            && !strs.All(_ => schemaAttribute.CaseExact ?
+                                schemaAttribute.CanonicalValues.Contains(_)
+                                : schemaAttribute.CanonicalValues.Contains(_, StringComparer.OrdinalIgnoreCase))
+                        )
                         {
                             throw new SCIMSchemaViolatedException(string.Format(Global.NotValidCanonicalValue, schemaAttribute.Name));
                         }


### PR DESCRIPTION
The attribute should be respect the CaseExact field. 