### PR TITLE
When extension schema not requested, schema will not found

### DIFF
--- a/src/Scim/SimpleIdServer.Scim/Helpers/AttributeReferenceEnricher.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/AttributeReferenceEnricher.cs
@@ -42,7 +42,7 @@ namespace SimpleIdServer.Scim.Helpers
 						var type = values.FirstOrDefault(v => v.SchemaAttribute.Name == "type");
 						var reference = values.FirstOrDefault(v => v.SchemaAttribute.Name == "$ref");
 						var schema = representation.GetSchema(attr);
-						var referenceAttribute = representation.GetSchema(attr).GetChildren(attr.SchemaAttribute).FirstOrDefault(v => v.Name == "$ref");
+						var referenceAttribute = schema?.GetChildren(attr.SchemaAttribute).FirstOrDefault(v => v.Name == "$ref");
 						if (value == null || string.IsNullOrWhiteSpace(value.ValueString) || reference != null || referenceAttribute == null || type == null || type.ValueString != attributeMapping.TargetResourceType)
                         {
 							continue;


### PR DESCRIPTION
When extension schema not requested, schema will not found (schema == null) and attribute does not need to be loaded