### PR TITLE
fix(masstransit): publish event after commit to avoid race condition with DB

### DIFF
--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
@@ -21,7 +21,7 @@ namespace SimpleIdServer.Scim.Persistence.EF
 
         public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId)
         {
-            return _scimDbContext.SCIMRepresentationLst
+            return _scimDbContext.SCIMRepresentationLst.AsNoTracking()
                 .Include(r => r.FlatAttributes)
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes).FirstOrDefaultAsync(r => r.Id == representationId);
         }

--- a/src/Scim/SimpleIdServer.Scim/Commands/Handlers/BaseCommandHandler.cs
+++ b/src/Scim/SimpleIdServer.Scim/Commands/Handlers/BaseCommandHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using MassTransit;
 using SimpleIdServer.Scim.ExternalEvents;
 using SimpleIdServer.Scim.Helpers;
@@ -19,14 +20,7 @@ namespace SimpleIdServer.Scim.Commands.Handlers
         }
         
         protected async Task NotifyAllReferences(List<RepresentationSyncResult> references) {
-            var tasks = new List<Task>();
-            foreach (var reference in references) {
-                // TODO remove
-                reference.AddedRepresentationAttributes.ForEach(x => { x.Representation = null; });
-                reference.RemovedRepresentationAttributes.ForEach(x => { x.Representation = null; });
-                reference.UpdatedRepresentationAttributes.ForEach(x => { x.Representation = null; });
-                tasks.Add(Notify(reference));
-            }
+            var tasks = references.Select(Notify).ToList();
             await Task.WhenAll(tasks);
         }
 

--- a/src/Scim/SimpleIdServer.Scim/Helpers/AttributeReferenceEnricher.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/AttributeReferenceEnricher.cs
@@ -34,6 +34,7 @@ namespace SimpleIdServer.Scim.Helpers
 			{
 				foreach(var representation in representationLst)
                 {
+	                var controllerName = _resourceTypeResolver.ResolveByResourceType(attributeMapping.TargetResourceType).ControllerName;
 					var attrs = representation.GetAttributesByAttrSchemaId(attributeMapping.SourceAttributeId).ToList();
 					foreach(var attr in attrs)
                     {
@@ -47,8 +48,7 @@ namespace SimpleIdServer.Scim.Helpers
                         {
 							continue;
                         }
-
-						var controllerName = _resourceTypeResolver.ResolveByResourceType(attributeMapping.TargetResourceType).ControllerName;
+						
 						representation.AddAttribute(attr, new SCIMRepresentationAttribute(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), referenceAttribute, referenceAttribute.SchemaId)
 						{
 							ValueReference = $"{baseUrl}/{controllerName}/{value.ValueString}"


### PR DESCRIPTION
If the event's consumer uses the ID from the event to query the DB, it might get the wrong data, as the SCIMReperesentation might not have been committed to the DB yet.