### PR TITLE
feat(SCIM): optimize performance

### DIFF
--- a/src/Scim/SimpleIdServer.Scim.Benchmark/SimpleIdServer.Scim.Benchmark.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Benchmark/SimpleIdServer.Scim.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />

--- a/src/Scim/SimpleIdServer.Scim.Domains/SimpleIdServer.Scim.Domains.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Domains/SimpleIdServer.Scim.Domains.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>netstandard2.0</TargetFramework>
     <Description>Contains the domain classes of SCIM2.0.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Scim/SimpleIdServer.Scim.Domains/SimpleIdServer.Scim.Domains.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Domains/SimpleIdServer.Scim.Domains.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>Contains the domain classes of SCIM2.0.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Scim/SimpleIdServer.Scim.MongoDb.Startup/Program.cs
+++ b/src/Scim/SimpleIdServer.Scim.MongoDb.Startup/Program.cs
@@ -12,7 +12,7 @@ namespace SimpleIdServer.Scim.MongoDb.Startup
             var host = Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults((cfg) =>
                 {
-                    cfg.UseUrls("http://*:5002");
+                    cfg.UseUrls("https://*:5003");
                     cfg.UseStartup<Startup>();
                 })
                 .Build();

--- a/src/Scim/SimpleIdServer.Scim.MongoDb.Startup/SimpleIdServer.Scim.MongoDb.Startup.csproj
+++ b/src/Scim/SimpleIdServer.Scim.MongoDb.Startup/SimpleIdServer.Scim.MongoDb.Startup.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.Parser/SimpleIdServer.Scim.Parser.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Parser/SimpleIdServer.Scim.Parser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>Parse SCIM filter into Expression.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Scim/SimpleIdServer.Scim.Parser/SimpleIdServer.Scim.Parser.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Parser/SimpleIdServer.Scim.Parser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>netstandard2.0</TargetFramework>
     <Description>Parse SCIM filter into Expression.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMAttributeMappingQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMAttributeMappingQueryRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using Microsoft.EntityFrameworkCore;
 using SimpleIdServer.Scim.Domains;
@@ -17,19 +17,19 @@ namespace SimpleIdServer.Scim.Persistence.EF
             _scimDbContext = scimDbContext;
         }
 
-        public async Task<IEnumerable<SCIMAttributeMapping>> GetAll()
+        public async Task<List<SCIMAttributeMapping>> GetAll()
         {
             var result = await _scimDbContext.SCIMAttributeMappingLst.ToListAsync();
             return result;
         }
 
-        public async Task<IEnumerable<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes)
+        public async Task<List<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes)
         {
             var result = await _scimDbContext.SCIMAttributeMappingLst.Where(a => sourceAttributes.Contains(a.SourceAttributeSelector)).ToListAsync();
             return result;
         }
 
-        public async Task<IEnumerable<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType)
+        public async Task<List<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType)
         {
             var result = await _scimDbContext.SCIMAttributeMappingLst.Where(a => a.SourceResourceType == sourceResourceType).ToListAsync();
             return result;

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
@@ -30,7 +30,7 @@ namespace SimpleIdServer.Scim.Persistence.EF {
         }
 
         public async Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType, GetSCIMResourceParameter parameter) {
-            var query = _scimDbContext.SCIMRepresentationLst
+            var query = _scimDbContext.SCIMRepresentationLst.AsNoTracking()
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes)
                 .Include(r => r.FlatAttributes).ThenInclude(s => s.SchemaAttribute);
             return await query.BuildResult(_scimDbContext, parameter.IncludedAttributes, parameter.ExcludedAttributes, representationId, resourceType);

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
@@ -9,47 +9,56 @@ using System.Linq;
 using System.Threading.Tasks;
 
 namespace SimpleIdServer.Scim.Persistence.EF {
-    public class EFSCIMRepresentationQueryRepository : ISCIMRepresentationQueryRepository {
+    public class EFSCIMRepresentationQueryRepository : ISCIMRepresentationQueryRepository 
+    {
         private readonly SCIMDbContext _scimDbContext;
 
-        public EFSCIMRepresentationQueryRepository(SCIMDbContext scimDbContext) {
+        public EFSCIMRepresentationQueryRepository(SCIMDbContext scimDbContext) 
+        {
             _scimDbContext = scimDbContext;
         }
 
-        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId) {
+        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId) 
+        {
             return _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.FlatAttributes)
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes).FirstOrDefaultAsync(r => r.Id == representationId);
         }
 
-        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType) {
+        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType) 
+        {
             return _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.FlatAttributes).ThenInclude(s => s.SchemaAttribute)
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes)
                 .FirstOrDefaultAsync(r => r.Id == representationId && r.ResourceType == resourceType);
         }
 
-        public async Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType, GetSCIMResourceParameter parameter) {
+        public async Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType, GetSCIMResourceParameter parameter) 
+        {
             var query = _scimDbContext.SCIMRepresentationLst.AsNoTracking()
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes)
                 .Include(r => r.FlatAttributes).ThenInclude(s => s.SchemaAttribute);
             return await query.BuildResult(_scimDbContext, parameter.IncludedAttributes, parameter.ExcludedAttributes, representationId, resourceType);
         }
 
-        public async Task<SearchSCIMRepresentationsResponse> FindSCIMRepresentations(SearchSCIMRepresentationsParameter parameter) {
+        public async Task<SearchSCIMRepresentationsResponse> FindSCIMRepresentations(SearchSCIMRepresentationsParameter parameter) 
+        {
             IQueryable<SCIMRepresentation> queryableRepresentations = _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.FlatAttributes)
                 .Where(s => s.ResourceType == parameter.ResourceType);
-            if (parameter.SortBy == null) {
+            if (parameter.SortBy == null) 
+            {
                 queryableRepresentations = queryableRepresentations.OrderBy(s => s.Id);
             }
 
-            if (parameter.Filter != null) {
+            if (parameter.Filter != null) 
+            {
                 var evaluatedExpression = parameter.Filter.Evaluate(queryableRepresentations);
                 queryableRepresentations = (IQueryable<SCIMRepresentation>)evaluatedExpression.Compile().DynamicInvoke(queryableRepresentations);
             }
 
-            if (parameter.SortBy != null) {
+            if (parameter.SortBy != null) 
+            {
                 return await parameter.SortBy.EvaluateOrderBy(
                     _scimDbContext,
                     queryableRepresentations,

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
@@ -31,7 +31,8 @@ namespace SimpleIdServer.Scim.Persistence.EF {
 
         public async Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType, GetSCIMResourceParameter parameter) {
             var query = _scimDbContext.SCIMRepresentationLst
-                .Include(r => r.Schemas).ThenInclude(s => s.Attributes);
+                .Include(r => r.Schemas).ThenInclude(s => s.Attributes)
+                .Include(r => r.FlatAttributes).ThenInclude(s => s.SchemaAttribute);
             return await query.BuildResult(_scimDbContext, parameter.IncludedAttributes, parameter.ExcludedAttributes, representationId, resourceType);
         }
 

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using Microsoft.EntityFrameworkCore;
 using SimpleIdServer.Persistence.Filters;
@@ -8,57 +8,47 @@ using SimpleIdServer.Scim.Persistence.EF.Extensions;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace SimpleIdServer.Scim.Persistence.EF
-{
-    public class EFSCIMRepresentationQueryRepository : ISCIMRepresentationQueryRepository
-    {
+namespace SimpleIdServer.Scim.Persistence.EF {
+    public class EFSCIMRepresentationQueryRepository : ISCIMRepresentationQueryRepository {
         private readonly SCIMDbContext _scimDbContext;
 
-        public EFSCIMRepresentationQueryRepository(SCIMDbContext scimDbContext)
-        {
+        public EFSCIMRepresentationQueryRepository(SCIMDbContext scimDbContext) {
             _scimDbContext = scimDbContext;
         }
 
-        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId)
-        {
-            return _scimDbContext.SCIMRepresentationLst.AsNoTracking()
+        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId) {
+            return _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.FlatAttributes)
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes).FirstOrDefaultAsync(r => r.Id == representationId);
         }
 
-        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType)
-        {
+        public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType) {
             return _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.FlatAttributes).ThenInclude(s => s.SchemaAttribute)
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes)
                 .FirstOrDefaultAsync(r => r.Id == representationId && r.ResourceType == resourceType);
         }
 
-        public async Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType, GetSCIMResourceParameter parameter)
-        {
+        public async Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId, string resourceType, GetSCIMResourceParameter parameter) {
             var query = _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes);
             return await query.BuildResult(_scimDbContext, parameter.IncludedAttributes, parameter.ExcludedAttributes, representationId, resourceType);
         }
 
-        public async Task<SearchSCIMRepresentationsResponse> FindSCIMRepresentations(SearchSCIMRepresentationsParameter parameter)
-        {
+        public async Task<SearchSCIMRepresentationsResponse> FindSCIMRepresentations(SearchSCIMRepresentationsParameter parameter) {
             IQueryable<SCIMRepresentation> queryableRepresentations = _scimDbContext.SCIMRepresentationLst
                 .Include(r => r.FlatAttributes)
                 .Where(s => s.ResourceType == parameter.ResourceType);
-            if (parameter.SortBy == null)
-            {
+            if (parameter.SortBy == null) {
                 queryableRepresentations = queryableRepresentations.OrderBy(s => s.Id);
             }
 
-            if (parameter.Filter != null)
-            {
+            if (parameter.Filter != null) {
                 var evaluatedExpression = parameter.Filter.Evaluate(queryableRepresentations);
                 queryableRepresentations = (IQueryable<SCIMRepresentation>)evaluatedExpression.Compile().DynamicInvoke(queryableRepresentations);
             }
 
-            if(parameter.SortBy != null)
-            {
+            if (parameter.SortBy != null) {
                 return await parameter.SortBy.EvaluateOrderBy(
                     _scimDbContext,
                     queryableRepresentations,

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFSCIMRepresentationQueryRepository.cs
@@ -8,7 +8,8 @@ using SimpleIdServer.Scim.Persistence.EF.Extensions;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace SimpleIdServer.Scim.Persistence.EF {
+namespace SimpleIdServer.Scim.Persistence.EF 
+{
     public class EFSCIMRepresentationQueryRepository : ISCIMRepresentationQueryRepository 
     {
         private readonly SCIMDbContext _scimDbContext;
@@ -20,7 +21,7 @@ namespace SimpleIdServer.Scim.Persistence.EF {
 
         public Task<SCIMRepresentation> FindSCIMRepresentationById(string representationId) 
         {
-            return _scimDbContext.SCIMRepresentationLst
+            return _scimDbContext.SCIMRepresentationLst.AsNoTracking()
                 .Include(r => r.FlatAttributes)
                 .Include(r => r.Schemas).ThenInclude(s => s.Attributes).FirstOrDefaultAsync(r => r.Id == representationId);
         }

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFTransaction.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/EFTransaction.cs
@@ -57,11 +57,15 @@ namespace SimpleIdServer.Scim.Persistence.EF
             var removeCollectionMethod = typeof(InternalEntityEntry).GetMethod("RemoveFromCollection", BindingFlags.Public | BindingFlags.Instance);
             foreach (var entry in representations)
             {
-                var representationId = (entry.Entity as SCIMRepresentation).Id;
                 var navigation = entry.EntityType.GetNavigations().Single(n => n.Name == "FlatAttributes");
                 foreach (var attrToRemove in attrsToRemove) removeCollectionMethod.Invoke(entry, new object[] { navigation, attrToRemove });
             }
 #pragma warning restore EF1001
+        }
+
+        public ValueTask DisposeAsync() 
+        {
+            return _dbContextTransaction.DisposeAsync();
         }
     }
 }

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/Extensions/EFSCIMExpressionLinqExtensions.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/Extensions/EFSCIMExpressionLinqExtensions.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
-using static MassTransit.ValidationResultExtensions;
 
 namespace SimpleIdServer.Scim.Persistence.EF.Extensions
 {
@@ -46,8 +45,7 @@ namespace SimpleIdServer.Scim.Persistence.EF.Extensions
                 result.FlatAttributes = filteredAttrs.ToList();
                 return result;
             }
-
-            representations = representations.Include(r => r.FlatAttributes).ThenInclude(s => s.SchemaAttribute);
+            
             return await representations.FirstOrDefaultAsync(r => r.Id == id && r.ResourceType == resourceType);
         }
 

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/Extensions/EFSCIMExpressionLinqExtensions.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/Extensions/EFSCIMExpressionLinqExtensions.cs
@@ -43,7 +43,6 @@ namespace SimpleIdServer.Scim.Persistence.EF.Extensions
             {
                 filteredAttrs = filteredAttrs.Where(a => a.RepresentationId == id);
                 var result = await representations.FirstOrDefaultAsync(r => r.Id == id && r.ResourceType == resourceType);
-                var includedFullPathLst = (includedAttributes != null && includedAttributes.Any()) ? includedAttributes.Where(i => i is SCIMComplexAttributeExpression).Select(i => i.GetFullPath()) : new List<string>();
                 result.FlatAttributes = filteredAttrs.ToList();
                 return result;
             }

--- a/src/Scim/SimpleIdServer.Scim.Persistence.EF/SimpleIdServer.Scim.Persistence.EF.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.EF/SimpleIdServer.Scim.Persistence.EF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>EntityFramework persistence layer for SCIM2.0.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.Persistence.MongoDB/MongoDbTransaction.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.MongoDB/MongoDbTransaction.cs
@@ -32,10 +32,13 @@ namespace SimpleIdServer.Scim.Persistence.MongoDB
 
         public void Dispose()
         {
-            if (_clientSessionHandle != null)
-            {
-                _clientSessionHandle.Dispose();
-            }
+            _clientSessionHandle?.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _clientSessionHandle?.Dispose();
+            return ValueTask.CompletedTask;
         }
     }
 }

--- a/src/Scim/SimpleIdServer.Scim.Persistence.MongoDB/SCIMAttributeMappingQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.MongoDB/SCIMAttributeMappingQueryRepository.cs
@@ -18,19 +18,19 @@ namespace SimpleIdServer.Scim.Persistence.MongoDB
             _scimDbContext = scimDbContext;
         }
 
-        public async Task<IEnumerable<SCIMAttributeMapping>> GetAll()
+        public async Task<List<SCIMAttributeMapping>> GetAll()
         {
             var attributeMappings = _scimDbContext.SCIMAttributeMappingLst;
             return await attributeMappings.AsQueryable().ToMongoListAsync();
         }
 
-        public async Task<IEnumerable<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes)
+        public async Task<List<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes)
         {
             var attributeMappings = _scimDbContext.SCIMAttributeMappingLst;
             return await attributeMappings.AsQueryable().Where(a => sourceAttributes.Contains(a.SourceAttributeSelector)).ToMongoListAsync();
         }
 
-        public async Task<IEnumerable<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType)
+        public async Task<List<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType)
         {
             var attributeMappings = _scimDbContext.SCIMAttributeMappingLst;
             return await attributeMappings.AsQueryable().Where(a => a.SourceResourceType == sourceResourceType).ToMongoListAsync();

--- a/src/Scim/SimpleIdServer.Scim.Persistence.MongoDB/SimpleIdServer.Scim.Persistence.MongoDB.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Persistence.MongoDB/SimpleIdServer.Scim.Persistence.MongoDB.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>MongoDB persistence layer for SCIM2.0.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.Postgre.Startup/Program.cs
+++ b/src/Scim/SimpleIdServer.Scim.Postgre.Startup/Program.cs
@@ -12,7 +12,7 @@ namespace SimpleIdServer.Scim.Postgre.Startup
             var host = Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults((cfg) =>
                 {
-                    cfg.UseUrls("http://*:5002");
+                    cfg.UseUrls("https://*:5003");
                     cfg.UseStartup<Startup>();
                 })
                 .Build();

--- a/src/Scim/SimpleIdServer.Scim.Postgre.Startup/SimpleIdServer.Scim.Postgre.Startup.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Postgre.Startup/SimpleIdServer.Scim.Postgre.Startup.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.Swashbuckle/SimpleIdServer.Scim.Swashbuckle.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Swashbuckle/SimpleIdServer.Scim.Swashbuckle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>Enrich the swagger documentation with SCIM schemas.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.SwashbuckleV6/SimpleIdServer.Scim.SwashbuckleV6.csproj
+++ b/src/Scim/SimpleIdServer.Scim.SwashbuckleV6/SimpleIdServer.Scim.SwashbuckleV6.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>Enrich the swagger (v6) documentation with SCIM schemas.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim/Commands/DeleteRepresentationCommand.cs
+++ b/src/Scim/SimpleIdServer.Scim/Commands/DeleteRepresentationCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-using SimpleIdServer.Scim.Domain;
 using SimpleIdServer.Scim.Domains;
 using SimpleIdServer.Scim.Infrastructure;
 

--- a/src/Scim/SimpleIdServer.Scim/Commands/Handlers/AddRepresentationCommandHandler.cs
+++ b/src/Scim/SimpleIdServer.Scim/Commands/Handlers/AddRepresentationCommandHandler.cs
@@ -83,7 +83,6 @@ namespace SimpleIdServer.Scim.Commands.Handlers
 
                 await transaction.Commit().ConfigureAwait(false);
                 await NotifyAllReferences(references).ConfigureAwait(false);
-
             }
 
             scimRepresentation.ApplyEmptyArray();

--- a/src/Scim/SimpleIdServer.Scim/Helpers/IRepresentationReferenceSync.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/IRepresentationReferenceSync.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using SimpleIdServer.Scim.Domains;
 using SimpleIdServer.Scim.DTOs;
@@ -9,9 +9,9 @@ namespace SimpleIdServer.Scim.Helpers
 {
     public interface IRepresentationReferenceSync
     {
-        IEnumerable<RepresentationSyncResult> Sync(IEnumerable<SCIMAttributeMapping> attributeMappingLst, string resourceType, SCIMRepresentation oldScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = false, bool isScimRepresentationRemoved = false);
-        IEnumerable<RepresentationSyncResult> Sync(string resourceType, SCIMRepresentation newSourceScimRepresentation, ICollection<SCIMPatchResult> patchOperations, string location, SCIMSchema schema, bool updateAllReference = false);
-        IEnumerable<RepresentationSyncResult> Sync(string resourceType, SCIMRepresentation oldSourceScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = true, bool isScimRepresentationRemoved = false);
+        Task<List<RepresentationSyncResult>> Sync(List<SCIMAttributeMapping> attributeMappingLst, string resourceType, SCIMRepresentation oldScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = false, bool isScimRepresentationRemoved = false);
+        Task<List<RepresentationSyncResult>> Sync(string resourceType, SCIMRepresentation newSourceScimRepresentation, ICollection<SCIMPatchResult> patchOperations, string location, SCIMSchema schema, bool updateAllReference = false);
+        Task<List<RepresentationSyncResult>> Sync(string resourceType, SCIMRepresentation oldSourceScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = true, bool isScimRepresentationRemoved = false);
         Task<bool> IsReferenceProperty(ICollection<string> attributes);
     }
 }

--- a/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationReferenceSync.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationReferenceSync.cs
@@ -101,7 +101,7 @@ namespace SimpleIdServer.Scim.Helpers
                                 if(type.ValueString != "direct")
                                 {
                                     type.ValueString = "direct";
-                                    result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { type });
+                                    result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { type }, sync);
                                 }
                             }
 
@@ -130,7 +130,7 @@ namespace SimpleIdServer.Scim.Helpers
                     }
             }
 
-            var syncIndirectReferences = await SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, mappedSchemas, location, mode, updateAllReferences);
+            var syncIndirectReferences = await SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, mappedSchemas, sync, updateAllReferences);
             sync.AddRange(syncIndirectReferences);
             return sync;
         }
@@ -186,7 +186,7 @@ namespace SimpleIdServer.Scim.Helpers
                                 if(typeAttr.ValueString != "direct") 
                                 {
                                     typeAttr.ValueString = "direct";
-                                    result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { typeAttr });
+                                    result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { typeAttr }, sync);
                                 }
                             }
 
@@ -215,7 +215,7 @@ namespace SimpleIdServer.Scim.Helpers
             }
 
 
-            var syncIndirectReferences = await SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, mappedSchemas, location, mode, updateAllReference);
+            var syncIndirectReferences = await SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, mappedSchemas, sync, updateAllReference);
             sync.AddRange(syncIndirectReferences);
             return sync;
         }
@@ -226,7 +226,7 @@ namespace SimpleIdServer.Scim.Helpers
             return attributes.All(a => attrs.Any(at => at.SourceAttributeSelector == a));
         }
 
-        protected async Task<List<RepresentationSyncResult>> SyncIndirectReferences(SCIMRepresentation newSourceScimRepresentation, List<RepresentationModified> allAdded, List<RepresentationModified> allRemoved, SCIMAttributeMapping propagatedAttribute, SCIMAttributeMapping selfReferenceAttribute, List<SCIMSchema> mappedSchemas, string location, Mode mode, bool updateAllReference)
+        protected async Task<List<RepresentationSyncResult>> SyncIndirectReferences(SCIMRepresentation newSourceScimRepresentation, List<RepresentationModified> allAdded, List<RepresentationModified> allRemoved, SCIMAttributeMapping propagatedAttribute, SCIMAttributeMapping selfReferenceAttribute, List<SCIMSchema> mappedSchemas, List<RepresentationSyncResult> sync, bool updateAllReference)
         {
             // Update 'indirect' references.
             var references = new List<RepresentationSyncResult>();
@@ -254,7 +254,7 @@ namespace SimpleIdServer.Scim.Helpers
                     foreach (var ta in typeAttrs)
                         ta.ValueString = newSourceScimRepresentation.DisplayName;
 
-                    result.UpdateReferenceAttributes(typeAttrs);
+                    result.UpdateReferenceAttributes(typeAttrs, sync);
 
                     references.Add(result);
                 }
@@ -476,7 +476,7 @@ namespace SimpleIdServer.Scim.Helpers
         {
             var attributes = new List<SCIMRepresentationAttribute>();
             var targetSchemaAttribute = targetSchema.GetAttributeById(attributeId);
-            var values = targetSchema.GetChildren(targetSchemaAttribute).ToList();
+            var values = targetSchema.GetChildren(targetSchemaAttribute);
             var value = values.FirstOrDefault(s => s.Name == SCIMConstants.StandardSCIMReferenceProperties.Value);
             var display = values.FirstOrDefault(s => IsDisplayName(s.Name));
             var type = values.FirstOrDefault(s => s.Name == SCIMConstants.StandardSCIMReferenceProperties.Type);

--- a/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationReferenceSync.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationReferenceSync.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
 // Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-using Microsoft.CodeAnalysis;
 using SimpleIdServer.Scim.Domains;
 using SimpleIdServer.Scim.DTOs;
 using SimpleIdServer.Scim.Exceptions;
@@ -9,7 +7,6 @@ using SimpleIdServer.Scim.Persistence;
 using SimpleIdServer.Scim.Resources;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -20,32 +17,32 @@ namespace SimpleIdServer.Scim.Helpers
 		private readonly ISCIMAttributeMappingQueryRepository _scimAttributeMappingQueryRepository;
 		private readonly ISCIMRepresentationCommandRepository _scimRepresentationCommandRepository;
 		private readonly ISCIMSchemaCommandRepository _scimSchemaCommandRepository;
-		private readonly IResourceTypeResolver _resourceTypeResolver;
 
 		public RepresentationReferenceSync(
 			ISCIMAttributeMappingQueryRepository scimAttributeMappingQueryRepository,
 			ISCIMRepresentationCommandRepository scimRepresentationCommandRepository,
-			ISCIMSchemaCommandRepository scimSchemaCommandRepository,
-			IResourceTypeResolver resourceTypeResolver)
+			ISCIMSchemaCommandRepository scimSchemaCommandRepository)
         {
 			_scimAttributeMappingQueryRepository = scimAttributeMappingQueryRepository;
 			_scimRepresentationCommandRepository = scimRepresentationCommandRepository;
 			_scimSchemaCommandRepository = scimSchemaCommandRepository;
-			_resourceTypeResolver = resourceTypeResolver;
 		}
 
-		public virtual IEnumerable<RepresentationSyncResult> Sync(string resourceType, SCIMRepresentation oldScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = false, bool isScimRepresentationRemoved = false)
+        public virtual async Task<List<RepresentationSyncResult>> Sync(string resourceType, SCIMRepresentation oldScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = true, bool isScimRepresentationRemoved = false)
         {
-            var attributeMappingLst = _scimAttributeMappingQueryRepository.GetBySourceResourceType(resourceType).Result;
-            return Sync(attributeMappingLst, resourceType, oldScimRepresentation, newSourceScimRepresentation, location, schema, updateAllReferences, isScimRepresentationRemoved);
-		}
+            var attributeMappingLst = await _scimAttributeMappingQueryRepository.GetBySourceResourceType(resourceType);
+            return await Sync(attributeMappingLst, resourceType, oldScimRepresentation, newSourceScimRepresentation, location, schema, updateAllReferences, isScimRepresentationRemoved);
+        }
 
-		public IEnumerable<RepresentationSyncResult> Sync(IEnumerable<SCIMAttributeMapping> attributeMappingLst, string resourceType, SCIMRepresentation oldScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = false, bool isScimRepresentationRemoved = false)
+        public async Task<List<RepresentationSyncResult>> Sync(List<SCIMAttributeMapping> attributeMappingLst, string resourceType, SCIMRepresentation oldScimRepresentation, SCIMRepresentation newSourceScimRepresentation, string location, SCIMSchema schema, bool updateAllReferences = false, bool isScimRepresentationRemoved = false)
         {
-			var result = new RepresentationSyncResult();
-            if (!attributeMappingLst.Any()) yield return result;
+            var result = new RepresentationSyncResult();
+            var sync = new List<RepresentationSyncResult>();
+            if (!attributeMappingLst.Any()) sync.Add(result);
 
-            var mappedSchemas = _scimSchemaCommandRepository.FindSCIMSchemaByResourceTypes(attributeMappingLst.Select(a => a.TargetResourceType).Union(attributeMappingLst.Select(a => a.SourceResourceType)).Distinct()).Result;
+            var targetSchemas =
+                (await _scimSchemaCommandRepository.FindSCIMSchemaByResourceTypes(attributeMappingLst
+                    .Select(a => a.TargetResourceType).Distinct())).ToList();
             var selfReferenceAttribute = attributeMappingLst.FirstOrDefault(a => a.IsSelf);
             var propagatedAttribute = attributeMappingLst.FirstOrDefault(a => a.Mode == Mode.PROPAGATE_INHERITANCE);
             var mode = propagatedAttribute == null ? Mode.STANDARD : Mode.PROPAGATE_INHERITANCE;
@@ -54,36 +51,35 @@ namespace SimpleIdServer.Scim.Helpers
             var allRemoved = new List<RepresentationModified>();
             foreach (var kvp in attributeMappingLst.GroupBy(m => m.SourceAttributeId))
             {
-                var sourceSchema = mappedSchemas.First(s => s.ResourceType == kvp.First().SourceResourceType && s.Attributes.Any(a => a.Id == kvp.Key));
-
-                var allIds = newSourceScimRepresentation.GetAttributesByAttrSchemaId(kvp.Key).SelectMany(a => newSourceScimRepresentation.GetChildren(a).Where(v => v.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value)).Select(v => v.ValueString);
-                IEnumerable<string> idsToBeRemoved = allIds, newIds = allIds, oldIds = new List<string>(), existingIds = new List<string>();
+                var allIds = newSourceScimRepresentation.GetAttributesByAttrSchemaId(kvp.Key).SelectMany(a => newSourceScimRepresentation.GetChildren(a).Where(v => v.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value)).Select(v => v.ValueString).ToList();
+                List<string> idsToBeRemoved = allIds, newIds = allIds;
                 if (!isScimRepresentationRemoved)
                 {
-                    oldIds = oldScimRepresentation.GetAttributesByAttrSchemaId(kvp.Key).SelectMany(a => oldScimRepresentation.GetChildren(a).Where(v => v.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value)).Select(v => v.ValueString);
-                    idsToBeRemoved = oldIds.Except(allIds);
-                    var duplicateIds = allIds.GroupBy(i => i).Where(i => i.Count() > 1);
+                    var oldIds = oldScimRepresentation.GetAttributesByAttrSchemaId(kvp.Key).SelectMany(a => oldScimRepresentation.GetChildren(a).Where(v => v.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value)).Select(v => v.ValueString).ToList();
+                    idsToBeRemoved = oldIds.Except(allIds).ToList();
+                    var duplicateIds = allIds.GroupBy(i => i).Where(i => i.Count() > 1).ToList();
                     if (duplicateIds.Any()) throw new SCIMUniquenessAttributeException(string.Format(Global.DuplicateReference, string.Join(",", duplicateIds.Select(_ => _.Key).Distinct())));
                     newIds = newIds.Except(oldIds).ToList();
-                    existingIds = oldIds.Except(idsToBeRemoved);
                 }
 
                 foreach (var attributeMapping in kvp.Where(r => !r.IsSelf))
                 {
                     result = new RepresentationSyncResult();
-                    var targetSchema = mappedSchemas.First(s => s.ResourceType == attributeMapping.TargetResourceType && s.Attributes.Any(a => a.Id == attributeMapping.TargetAttributeId));
+                    var targetSchema = targetSchemas.First(s => s.ResourceType == attributeMapping.TargetResourceType);
                     var targetAttribute = targetSchema.GetAttributeById(attributeMapping.TargetAttributeId);
-                    var sourceAttribute = sourceSchema.GetAttributeById(attributeMapping.SourceAttributeId);
+                    var sourceAttribute = schema.GetAttributeById(attributeMapping.SourceAttributeId);
                     var targetAttributeValue = targetSchema.GetChildren(targetAttribute).Single(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Value);
                     var targetAttributeType = targetSchema.GetChildren(targetAttribute).SingleOrDefault(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Type);
                     if (isScimRepresentationRemoved)
                     {
                         var removedIds = new List<string>();
-                        foreach (var paginatedResult in _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(newIds, newSourceScimRepresentation.Id, targetAttributeValue.Id))
-                        {
-                            result.RemoveReferenceAttributes(paginatedResult);
-                            removedIds.AddRange(paginatedResult.Select(a => a.RepresentationId).Distinct());
-                        }
+                        var paginatedResult =
+                            await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(newIds,
+                                newSourceScimRepresentation.Id, targetAttributeValue.Id);
+
+                        result.RemoveReferenceAttributes(paginatedResult);
+                        removedIds.AddRange(paginatedResult.Select(a => a.RepresentationId).Distinct());
+
 
                         var notRemovedIds = newIds.Except(removedIds);
                         allRemoved.AddRange(notRemovedIds.Select(id => new RepresentationModified(id, false)));
@@ -91,30 +87,28 @@ namespace SimpleIdServer.Scim.Helpers
                     }
                     else
                     {
-                        foreach (var paginatedResult in _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(idsToBeRemoved, newSourceScimRepresentation.Id, targetAttributeValue.Id))
-                            result.RemoveReferenceAttributes(paginatedResult);
+                        var paginatedResult = await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(idsToBeRemoved, newSourceScimRepresentation.Id, targetAttributeValue.Id);
+                        result.RemoveReferenceAttributes(paginatedResult);
 
-                        foreach(var representations in _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
-                            foreach(var rep in representations)
-                            {
-                                var fa = rep.FlatAttributes.SingleOrDefault(a => a.SchemaAttributeId == targetAttributeValue.Id && a.ValueString == newSourceScimRepresentation.Id);
-                                if(fa == null)
-                                    result.AddReferenceAttributes(BuildScimRepresentationAttribute(rep.Id, attributeMapping.TargetAttributeId, newSourceScimRepresentation, mode, newSourceScimRepresentation.ResourceType, targetSchema));
-                                else
+                        foreach(var rep in await _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
+                        {
+                            var fa = rep.FlatAttributes.SingleOrDefault(a => a.SchemaAttributeId == targetAttributeValue.Id && a.ValueString == newSourceScimRepresentation.Id);
+                            if(fa == null)
+                                result.AddReferenceAttributes(BuildScimRepresentationAttribute(rep.Id, attributeMapping.TargetAttributeId, newSourceScimRepresentation, mode, newSourceScimRepresentation.ResourceType, targetSchema));
+                            else {
+                                var type = rep.FlatAttributes.Single(a => a.SchemaAttributeId == targetAttributeType.Id && a.ParentAttributeId == fa.ParentAttributeId);
+                                if(type.ValueString != "direct")
                                 {
-                                    var type = rep.FlatAttributes.Single(a => a.SchemaAttributeId == targetAttributeType.Id && a.ParentAttributeId == fa.ParentAttributeId);
-                                    if(type.ValueString != "direct")
-                                    {
-                                        type.ValueString = "direct";
-                                        result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { type });
-                                    }
+                                    type.ValueString = "direct";
+                                    result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { type });
                                 }
-
-                                UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);                        
                             }
-                        
-                        var removedIds = result.RemovedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId);
-                        var addedIds = result.AddedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId);
+
+                            UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);
+                        }
+
+                        var removedIds = result.RemovedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId).ToList();
+                        var addedIds = result.AddedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId).ToList();
                         var notRemovedIds = idsToBeRemoved.Except(removedIds);
                         var notAddedIds = newIds.Except(addedIds);
                         allRemoved.AddRange(notRemovedIds.Select(id => new RepresentationModified(id, false)));
@@ -123,92 +117,87 @@ namespace SimpleIdServer.Scim.Helpers
                         allAdded.AddRange(addedIds.Select(id => new RepresentationModified(id, true)));
                     }
 
-                    yield return result;
+                    sync.Add(result);
                 }
 
                 if(newIds.Any())
                     foreach (var attributeMapping in kvp.Where(a => a.IsSelf))
                     {
                         var sourceAttribute = schema.GetAttributeById(attributeMapping.SourceAttributeId);
-                        foreach (var representations in _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
-                            foreach (var rep in representations)
-                                UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);
+                        foreach (var rep in await _scimRepresentationCommandRepository.FindPaginatedRepresentations( newIds, attributeMapping.TargetResourceType))
+                            UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);
                     }
             }
 
-            var syncIndirectReferences = SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, mappedSchemas, location, mode, updateAllReferences);
-            foreach (var syncIndirectReference in syncIndirectReferences)
-                yield return syncIndirectReference;
+            var syncIndirectReferences = await SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, targetSchemas, location, mode, updateAllReferences);
+            sync.AddRange(syncIndirectReferences);
+            return sync;
         }
 
-		public  IEnumerable<RepresentationSyncResult> Sync(string resourceType, SCIMRepresentation newSourceScimRepresentation, ICollection<SCIMPatchResult> patchOperations, string location, SCIMSchema schema, bool updateAllReference = false)
-		{
-			var result = new RepresentationSyncResult();
-			var attributeMappingLst = _scimAttributeMappingQueryRepository.GetBySourceResourceType(resourceType).Result;
-			if (!attributeMappingLst.Any()) yield return result;
+        public async Task<List<RepresentationSyncResult>> Sync(string resourceType, SCIMRepresentation newSourceScimRepresentation, ICollection<SCIMPatchResult> patchOperations, string location, SCIMSchema schema, bool updateAllReference = false)
+        {
+            var result = new RepresentationSyncResult();
+            var attributeMappingLst = await _scimAttributeMappingQueryRepository.GetBySourceResourceType(resourceType);
+            var sync = new List<RepresentationSyncResult>();
+            if (!attributeMappingLst.Any()) sync.Add(result);
 
-            var mappedSchemas = _scimSchemaCommandRepository.FindSCIMSchemaByResourceTypes(attributeMappingLst.Select(a => a.TargetResourceType).Union(attributeMappingLst.Select(a => a.SourceResourceType)).Distinct()).Result;
+            var targetSchemas = (await _scimSchemaCommandRepository.FindSCIMSchemaByResourceTypes(attributeMappingLst.Select(a => a.TargetResourceType).Distinct())).ToList();
             var selfReferenceAttribute = attributeMappingLst.FirstOrDefault(a => a.IsSelf);
-			var propagatedAttribute = attributeMappingLst.FirstOrDefault(a => a.Mode == Mode.PROPAGATE_INHERITANCE);
-			var mode = propagatedAttribute == null ? Mode.STANDARD : Mode.PROPAGATE_INHERITANCE;
+            var propagatedAttribute = attributeMappingLst.FirstOrDefault(a => a.Mode == Mode.PROPAGATE_INHERITANCE);
+            var mode = propagatedAttribute == null ? Mode.STANDARD : Mode.PROPAGATE_INHERITANCE;
             var allAdded = new List<RepresentationModified>();
             var allRemoved = new List<RepresentationModified>();
 
             // Update 'direct' references.
             foreach (var kvp in attributeMappingLst.GroupBy(m => m.SourceAttributeId))
-			{
-                var sourceSchema = mappedSchemas.First(s => s.ResourceType == kvp.First().SourceResourceType && s.Attributes.Any(a => a.Id == kvp.Key));
-
+            {
                 var allCurrentIds = newSourceScimRepresentation.GetAttributesByAttrSchemaId(kvp.Key).SelectMany(a => newSourceScimRepresentation.GetChildren(a).Where(v => v.SchemaAttribute.Name == "value")).Select(v => v.ValueString);
-				var newIds = patchOperations
-					.Where(p => p.Operation == SCIMPatchOperations.ADD && p.Attr.SchemaAttributeId == kvp.Key)
-					.SelectMany(p => patchOperations.Where(po => po.Attr.ParentAttributeId == p.Attr.Id && po.Attr.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value).Select(po => po.Attr.ValueString));
-				var idsToBeRemoved = patchOperations
-					.Where(p => p.Operation == SCIMPatchOperations.REMOVE && p.Attr.SchemaAttributeId == kvp.Key)
-					.SelectMany(p => patchOperations.Where(po => po.Attr.ParentAttributeId == p.Attr.Id && po.Attr.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value).Select(po => po.Attr.ValueString));
-				var duplicateIds = allCurrentIds.GroupBy(i => i).Where(i => i.Count() > 1);
-				if (duplicateIds.Any()) throw new SCIMUniquenessAttributeException(string.Format(Global.DuplicateReference, string.Join(",", duplicateIds.Select(_ => _.Key).Distinct())));
-                foreach (var attributeMapping in kvp.Where(a => !a.IsSelf))
-                {
-                    var sourceAttribute = sourceSchema.GetAttributeById(attributeMapping.SourceAttributeId);
-                    var targetSchema = mappedSchemas.First(s => s.ResourceType == attributeMapping.TargetResourceType && s.Attributes.Any(a => a.Id == attributeMapping.TargetAttributeId));
+                var newIds = patchOperations
+                    .Where(p => p.Operation == SCIMPatchOperations.ADD && p.Attr.SchemaAttributeId == kvp.Key)
+                    .SelectMany(p => patchOperations.Where(po => po.Attr.ParentAttributeId == p.Attr.Id && po.Attr.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value).Select(po => po.Attr.ValueString)).ToList();
+                var idsToBeRemoved = patchOperations
+                    .Where(p => p.Operation == SCIMPatchOperations.REMOVE && p.Attr.SchemaAttributeId == kvp.Key)
+                    .SelectMany(p => patchOperations.Where(po => po.Attr.ParentAttributeId == p.Attr.Id && po.Attr.SchemaAttribute.Name == SCIMConstants.StandardSCIMReferenceProperties.Value).Select(po => po.Attr.ValueString)).ToList();
+                var duplicateIds = allCurrentIds.GroupBy(i => i).Where(i => i.Count() > 1).ToList();
+                if (duplicateIds.Any()) throw new SCIMUniquenessAttributeException(string.Format(Global.DuplicateReference, string.Join(",", duplicateIds.Select(_ => _.Key).Distinct())));
+                foreach (var attributeMapping in kvp.Where(a => !a.IsSelf)) {
+                    var sourceAttribute = schema.GetAttributeById(attributeMapping.SourceAttributeId);
+                    var targetSchema = targetSchemas.First(s => s.ResourceType == attributeMapping.TargetResourceType);
                     var targetAttribute = targetSchema.GetAttributeById(attributeMapping.TargetAttributeId);
                     var targetAttributeValue = targetSchema.GetChildren(targetAttribute).Single(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Value);
                     var targetAttributeType = targetSchema.GetChildren(targetAttribute).SingleOrDefault(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Type);
                     if (targetAttributeValue != null)
                     {
                         result = new RepresentationSyncResult();
-                        foreach (var paginatedResult in _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(idsToBeRemoved, newSourceScimRepresentation.Id, targetAttributeValue.Id))
-                            result.RemoveReferenceAttributes(paginatedResult);
+                        var paginatedResult = await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(idsToBeRemoved, newSourceScimRepresentation.Id, targetAttributeValue.Id);
+                        result.RemoveReferenceAttributes(paginatedResult);
 
-                        foreach (var representations in _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
-                            foreach (var rep in representations)
+                        foreach (var rep in await _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
+                        {
+                            var attr = rep.FlatAttributes.FirstOrDefault(a => a.ValueString == newSourceScimRepresentation.Id && a.SchemaAttributeId == targetAttributeValue.Id);
+                            if (attr == null)
+                                result.AddReferenceAttributes(BuildScimRepresentationAttribute(rep.Id, attributeMapping.TargetAttributeId, newSourceScimRepresentation, mode, newSourceScimRepresentation.ResourceType, targetSchema));
+                            else
                             {
-                                var attr = rep.FlatAttributes.FirstOrDefault(a => a.ValueString == newSourceScimRepresentation.Id && a.SchemaAttributeId == targetAttributeValue.Id);
-                                if (attr == null)
-                                    result.AddReferenceAttributes(BuildScimRepresentationAttribute(rep.Id, attributeMapping.TargetAttributeId, newSourceScimRepresentation, mode, newSourceScimRepresentation.ResourceType, targetSchema));
-                                else
-                                {
-                                    var typeAttr = rep.FlatAttributes.Single(a => a.SchemaAttributeId == targetAttributeType.Id && a.ParentAttributeId == attr.ParentAttributeId);
-                                    if(typeAttr.ValueString != "direct")
-                                    {
-                                        typeAttr.ValueString = "direct";
-                                        result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { typeAttr });
-                                    }
+                                var typeAttr = rep.FlatAttributes.Single(a => a.SchemaAttributeId == targetAttributeType.Id && a.ParentAttributeId == attr.ParentAttributeId);
+                                if(typeAttr.ValueString != "direct") {
+                                    typeAttr.ValueString = "direct";
+                                    result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { typeAttr });
                                 }
-
-                                UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);
                             }
 
-                        var removedIds = result.RemovedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId);
-                        var addedIds = result.AddedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId);
+                            UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);
+                        }
+
+                        var removedIds = result.RemovedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId).ToList();
+                        var addedIds = result.AddedRepresentationAttributes.Where(a => a.SchemaAttributeId == targetAttributeValue.Id).Select(r => r.RepresentationId).ToList();
                         var notRemovedIds = idsToBeRemoved.Except(removedIds);
                         var notAddedIds = newIds.Except(addedIds);
                         allRemoved.AddRange(notRemovedIds.Select(id => new RepresentationModified(id, false)));
                         allRemoved.AddRange(removedIds.Select(id => new RepresentationModified(id, true)));
                         allAdded.AddRange(notAddedIds.Select(id => new RepresentationModified(id, false)));
                         allAdded.AddRange(addedIds.Select(id => new RepresentationModified(id, true)));
-                        yield return result;
+                        sync.Add(result);
                     }
                 }
 
@@ -216,69 +205,66 @@ namespace SimpleIdServer.Scim.Helpers
                     foreach(var attributeMapping in kvp.Where(a => a.IsSelf))
                     {
                         var sourceAttribute = schema.GetAttributeById(attributeMapping.SourceAttributeId);
-                        foreach (var representations in _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
-                            foreach(var rep in representations)
+                        foreach (var rep in await _scimRepresentationCommandRepository.FindPaginatedRepresentations(newIds, attributeMapping.TargetResourceType))
                             UpdateScimRepresentation(newSourceScimRepresentation, rep, schema, sourceAttribute);
                     }
             }
 
 
-            var syncIndirectReferences = SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, mappedSchemas, location, mode, updateAllReference);
-            foreach (var syncIndirectReference in syncIndirectReferences)
-                yield return syncIndirectReference;
-		}
+            var syncIndirectReferences = await SyncIndirectReferences(newSourceScimRepresentation, allAdded, allRemoved, propagatedAttribute, selfReferenceAttribute, targetSchemas, location, mode, updateAllReference);
+            sync.AddRange(syncIndirectReferences);
+            return sync;
+        }
 
-		public async virtual Task<bool> IsReferenceProperty(ICollection<string> attributes)
+        public virtual async Task<bool> IsReferenceProperty(ICollection<string> attributes)
         {
-			var attrs = await _scimAttributeMappingQueryRepository.GetBySourceAttributes(attributes);
-			return attributes.All(a => attrs.Any(at => at.SourceAttributeSelector == a));
-		}
+            var attrs = await _scimAttributeMappingQueryRepository.GetBySourceAttributes(attributes);
+            return attributes.All(a => attrs.Any(at => at.SourceAttributeSelector == a));
+        }
 
-        protected IEnumerable<RepresentationSyncResult> SyncIndirectReferences(SCIMRepresentation newSourceScimRepresentation, IEnumerable<RepresentationModified> allAdded, IEnumerable<RepresentationModified> allRemoved, SCIMAttributeMapping propagatedAttribute, SCIMAttributeMapping selfReferenceAttribute, IEnumerable<SCIMSchema> mappedSchemas, string location, Mode mode, bool updateAllReference)
+        protected async Task<List<RepresentationSyncResult>> SyncIndirectReferences(SCIMRepresentation newSourceScimRepresentation, List<RepresentationModified> allAdded, List<RepresentationModified> allRemoved, SCIMAttributeMapping propagatedAttribute, SCIMAttributeMapping selfReferenceAttribute, List<SCIMSchema> targetSchemas, string location, Mode mode, bool updateAllReference)
         {
             // Update 'indirect' references.
-            if (propagatedAttribute != null && selfReferenceAttribute != null)
-            {
+            var references = new List<RepresentationSyncResult>();
+            if (propagatedAttribute != null && selfReferenceAttribute != null) {
                 var result = new RepresentationSyncResult();
-                var sourceSchema = mappedSchemas.First(s => s.ResourceType == propagatedAttribute.SourceResourceType && s.Attributes.Any(a => a.Id == propagatedAttribute.SourceAttributeId));
-                var targetSchema = mappedSchemas.First(s => s.ResourceType == propagatedAttribute.TargetResourceType && s.Attributes.Any(a => a.Id == propagatedAttribute.TargetAttributeId));
+                var targetSchema = targetSchemas.Single(s => s.Name == propagatedAttribute.TargetResourceType);
+                var sourceSchema = targetSchemas.Single(s => s.Name == propagatedAttribute.SourceResourceType);
                 var parentAttr = targetSchema.GetAttributeById(propagatedAttribute.TargetAttributeId);
                 var selfParentAttr = sourceSchema.GetAttributeById(selfReferenceAttribute.SourceAttributeId);
                 var valueAttr = targetSchema.GetChildren(parentAttr).Single(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Value);
                 var displayAttr = targetSchema.GetChildren(parentAttr).Single(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Display);
                 var selfValueAttr = sourceSchema.GetChildren(selfParentAttr).Single(a => a.Name == SCIMConstants.StandardSCIMReferenceProperties.Value);
-                var addedDirectChildrenIds = allAdded.Where(r => r.IsDirect).Select(r => r.Id);
-                var removedDirectChildrenIds = allRemoved.Where(r => r.IsDirect).Select(r => r.Id);
-                var addedIndirectChildrenIds = allAdded.Where(r => !r.IsDirect).Select(r => r.Id);
-                var removedIndirectChildrenIds = allRemoved.Where(r => !r.IsDirect).Select(r => r.Id);
+                var addedDirectChildrenIds = allAdded.Where(r => r.IsDirect).Select(r => r.Id).ToList();
+                var removedDirectChildrenIds = allRemoved.Where(r => r.IsDirect).Select(r => r.Id).ToList();
+                var addedIndirectChildrenIds = allAdded.Where(r => !r.IsDirect).Select(r => r.Id).ToList();
+                var removedIndirectChildrenIds = allRemoved.Where(r => !r.IsDirect).Select(r => r.Id).ToList();
 
-                IEnumerable<SCIMRepresentation> allParents = null;
+                List<SCIMRepresentation> allParents = null;
                 // Update displayName.
                 if(updateAllReference)
                 {
-                    foreach (var propagatedChildren in _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(newSourceScimRepresentation.Id, valueAttr.Id))
-                    {
-                        var typeAttrs = propagatedChildren.Where(c => c.SchemaAttributeId == displayAttr.Id && !addedDirectChildrenIds.Contains(c.RepresentationId)).ToList();
-                        foreach (var ta in typeAttrs)
-                            ta.ValueString = newSourceScimRepresentation.DisplayName;
+                    var propagatedChildren = await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes( newSourceScimRepresentation.Id, valueAttr.Id);
+                    var typeAttrs = propagatedChildren.Where(c => c.SchemaAttributeId == displayAttr.Id && !addedDirectChildrenIds.Contains(c.RepresentationId)).ToList();
+                    foreach (var ta in typeAttrs)
+                        ta.ValueString = newSourceScimRepresentation.DisplayName;
 
-                        result.UpdateReferenceAttributes(typeAttrs);
-                    }
+                    result.UpdateReferenceAttributes(typeAttrs);
 
-                    yield return result;
+                    references.Add(result);
                 }
 
                 // Add indirect reference to the parent.
                 if (addedDirectChildrenIds.Any())
                 {
                     result = new RepresentationSyncResult();
-                    allParents = ResolveParents(newSourceScimRepresentation, selfReferenceAttribute).ToList();
+                    allParents = await GetParents(new List<SCIMRepresentation> { newSourceScimRepresentation }, selfReferenceAttribute);
                     foreach (var parent in allParents)
                         foreach(var addedId in addedDirectChildrenIds)
                             if (!parent.FlatAttributes.Any(a => a.SchemaAttributeId == selfValueAttr.Id && a.ValueString == addedId))
                                 result.AddReferenceAttributes(BuildScimRepresentationAttribute(addedId, propagatedAttribute.TargetAttributeId, parent, Mode.PROPAGATE_INHERITANCE, parent.ResourceType, targetSchema, false));
 
-                    yield return result;
+                    references.Add(result);
                 }
 
                 // If at least one parent has a reference to the child then add indirect reference to the child.
@@ -286,24 +272,23 @@ namespace SimpleIdServer.Scim.Helpers
                 if (removedDirectChildrenIds.Any())
                 {
                     result = new RepresentationSyncResult();
-                    if(allParents == null)
-                        allParents = ResolveParents(newSourceScimRepresentation, selfReferenceAttribute).ToList();
-                    var children = ResolveChildren(newSourceScimRepresentation, selfReferenceAttribute);
-                    foreach (var removedDirectChild in removedDirectChildrenIds)
-                    {
+                    allParents ??= await GetParents(new List<SCIMRepresentation> { newSourceScimRepresentation }, selfReferenceAttribute);
+
+                    var children = await GetChildren(new List<SCIMRepresentation> { newSourceScimRepresentation }, selfReferenceAttribute);
+                    foreach (var removedDirectChild in removedDirectChildrenIds) {
                         if(allParents.Any(p => p.FlatAttributes.Any(a => a.SchemaAttributeId == selfValueAttr.Id && a.ValueString == removedDirectChild)) || children.Any(p => p.FlatAttributes.Any(a => a.SchemaAttributeId == selfValueAttr.Id && a.ValueString == removedDirectChild)))
                             result.AddReferenceAttributes(BuildScimRepresentationAttribute(removedDirectChild, propagatedAttribute.TargetAttributeId, newSourceScimRepresentation, Mode.PROPAGATE_INHERITANCE, newSourceScimRepresentation.ResourceType, targetSchema, false));
                         else
                         {
                             foreach(var parent in allParents)
                             {
-                                foreach (var paginatedResult in _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(new List<string> { removedDirectChild }, parent.Id, valueAttr.Id))
-                                    result.RemoveReferenceAttributes(paginatedResult);
+                                var paginatedResult = await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(new List<string> { removedDirectChild }, parent.Id, valueAttr.Id);
+                                result.RemoveReferenceAttributes(paginatedResult);
                             }
                         }
                     }
 
-                    yield return result;
+                    references.Add(result);
                 }
 
                 // Populate the children.
@@ -316,16 +301,19 @@ namespace SimpleIdServer.Scim.Helpers
                     var allIds = new List<string>();
                     allIds.AddRange(addedIndirectChildrenIds);
                     allIds.AddRange(removedIndirectChildrenIds);
-                    var notRemovedChildrenIds = childrenIds.Except(removedIndirectChildrenIds);
-                    var indirectChildren = _scimRepresentationCommandRepository.FindSCIMRepresentationByIds(allIds).Result;
-                    var notRemoved = _scimRepresentationCommandRepository.FindSCIMRepresentationByIds(notRemovedChildrenIds).Result;
-                    var notRemovedChildren = notRemoved.SelectMany(r => ResolveChildren(r, selfReferenceAttribute).ToList());
+                    var notRemovedChildrenIds = childrenIds.Except(removedIndirectChildrenIds).ToList();
+                    var indirectChildren = await _scimRepresentationCommandRepository.FindPaginatedRepresentations(allIds);
+                    var notRemoved = await _scimRepresentationCommandRepository.FindPaginatedRepresentations(notRemovedChildrenIds);
+
+                    var notRemovedChildren = new List<SCIMRepresentation>();
+                    notRemovedChildren.AddRange(await GetChildren(notRemoved, selfReferenceAttribute));
+
                     var notRemovedChldIds = notRemovedChildren.Select(r => r.Id);
 
                     foreach (var indirectChild in indirectChildren)
                     {
-                        var allChld = ResolveChildren(indirectChild, selfReferenceAttribute);
-                        foreach (var children in ResolvePropagatedChildren(newSourceScimRepresentation.Id, indirectChild, selfReferenceAttribute, valueAttr, allChld))
+                        var allChld = await GetChildren(new List<SCIMRepresentation> { indirectChild }, selfReferenceAttribute);
+                        foreach (var children in await ResolvePropagatedChildren(newSourceScimRepresentation.Id, indirectChild, selfReferenceAttribute, valueAttr, allChld))
                         {
                             if(addedIndirectChildrenIds.Contains(indirectChild.Id))
                             {
@@ -346,9 +334,8 @@ namespace SimpleIdServer.Scim.Helpers
                                     var parentAttrs = children.Where(c => c.SchemaAttributeId == propagatedAttribute.TargetAttributeId && c.RepresentationId == representationId);
                                     foreach (var pa in parentAttrs)
                                     {
-                                        var subAttrs = children.Where(c => c.ParentAttributeId == pa.Id);
-                                        if (subAttrs.Any(a => a.SchemaAttributeId == valueAttr.Id && notRemovedChldIds.Contains(a.ValueString)))
-                                        {
+                                        var subAttrs = children.Where(c => c.ParentAttributeId == pa.Id).ToList();
+                                        if (subAttrs.Any(a => a.SchemaAttributeId == valueAttr.Id && notRemovedChldIds.Contains(a.ValueString))) {
                                             atLeastOneParent = true;
                                             break;
                                         }
@@ -367,53 +354,78 @@ namespace SimpleIdServer.Scim.Helpers
                         }
                     }
 
-                    yield return result;
+                    references.Add(result);
                 }
             }
+
+            return references;
         }
 
-        protected virtual IEnumerable<SCIMRepresentation> ResolveParents(SCIMRepresentation scimRepresentation, SCIMAttributeMapping selfReferenceAttribute)
-        {
-            var fullPath = $"{selfReferenceAttribute.SourceAttributeSelector}.{SCIMConstants.StandardSCIMReferenceProperties.Value}";
-            var parents = _scimRepresentationCommandRepository.FindSCIMRepresentationsByAttributeFullPath(fullPath, new List<string> { scimRepresentation.Id }, selfReferenceAttribute.SourceResourceType).Result;
-			foreach (var parent in parents)
-				yield return parent;
-            foreach (var parent in parents)
-			{
-				foreach (var p in ResolveParents(parent, selfReferenceAttribute))
-					yield return p;
-			}
+        protected virtual async Task<List<SCIMRepresentation>> GetChildren(
+            List<SCIMRepresentation> scimRepresentations,
+            SCIMAttributeMapping selfReferenceAttribute) {
+            var childrenRepresentations = scimRepresentations.ToDictionary(x => x.Id, x => x);
+            await ResolveChildren(scimRepresentations, selfReferenceAttribute, childrenRepresentations);
+            return childrenRepresentations.Values.ToList();
         }
 
-        protected virtual IEnumerable<SCIMRepresentation> ResolveChildren(SCIMRepresentation scimRepresentation, SCIMAttributeMapping selfReferenceAttribute)
-        {
+        protected virtual async Task<List<SCIMRepresentation>> GetParents(
+            List<SCIMRepresentation> scimRepresentations,
+            SCIMAttributeMapping selfReferenceAttribute
+            ) {
+            var parents = scimRepresentations.ToDictionary(x => x.Id, x => x);
+            await ResolveParents(scimRepresentations, selfReferenceAttribute, parents);
+            return parents.Values.ToList();
+        }
+
+        private async Task ResolveParents(
+            List<SCIMRepresentation> scimRepresentations,
+            SCIMAttributeMapping selfReferenceAttribute, Dictionary<string, SCIMRepresentation> representations) {
             var fullPath = $"{selfReferenceAttribute.SourceAttributeSelector}.{SCIMConstants.StandardSCIMReferenceProperties.Value}";
-            var childrenIds = scimRepresentation.FlatAttributes.Where(f => f.FullPath == fullPath).Select(f => f.ValueString);
-            foreach (var children in _scimRepresentationCommandRepository.FindPaginatedRepresentations(childrenIds, selfReferenceAttribute.TargetResourceType))
-            {
-                foreach (var child in children)
-                {
-                    yield return child;
-                    foreach (var chld in ResolveChildren(child, selfReferenceAttribute))
-                    {
-                        yield return chld;
-                    }
-                }
+            var parents = await _scimRepresentationCommandRepository.FindSCIMRepresentationsByAttributeFullPath(fullPath, scimRepresentations.Select(x => x.Id), selfReferenceAttribute.SourceResourceType);
+            var newParents = parents.Where(x => !representations.ContainsKey(x.Id)).ToList();
+            if (!newParents.Any()) return;
+            foreach (var parent in newParents) {
+                representations[parent.Id] = parent;
             }
+            await ResolveParents(newParents.ToList(), selfReferenceAttribute, representations);
         }
 
-        protected virtual IEnumerable<IEnumerable<SCIMRepresentationAttribute>> ResolvePropagatedChildren(string sourceRepresentationId, SCIMRepresentation scimRepresentation, SCIMAttributeMapping selfReferenceAttribute, SCIMSchemaAttribute targetAttributeId, IEnumerable<SCIMRepresentation> allChildren)
+        private async Task ResolveChildren(
+            List<SCIMRepresentation> scimRepresentations,
+            SCIMAttributeMapping selfReferenceAttribute,
+            Dictionary<string, SCIMRepresentation> representations) {
+            var fullPath =
+                $"{selfReferenceAttribute.SourceAttributeSelector}.{SCIMConstants.StandardSCIMReferenceProperties.Value}";
+            var newChildrenIds = scimRepresentations.SelectMany(x => x.FlatAttributes)
+                .Where(f => f.FullPath == fullPath)
+                .Select(f => f.ValueString)
+                .Where(x => !representations.ContainsKey(x))
+                .Distinct()
+                .ToList();
+            var childrenRepresentations = await _scimRepresentationCommandRepository.FindPaginatedRepresentations(newChildrenIds,
+                selfReferenceAttribute.TargetResourceType);
+            if (!childrenRepresentations.Any()) return;
+            foreach (var newChild in childrenRepresentations) {
+                representations[newChild.Id] = newChild;
+            }
+            await ResolveChildren(childrenRepresentations, selfReferenceAttribute, representations);
+        }
+
+        protected virtual async Task<List<List<SCIMRepresentationAttribute>>> ResolvePropagatedChildren(string sourceRepresentationId, SCIMRepresentation scimRepresentation, SCIMAttributeMapping selfReferenceAttribute, SCIMSchemaAttribute targetAttributeId, List<SCIMRepresentation> allChildren)
         {
             var fullPath = $"{selfReferenceAttribute.SourceAttributeSelector}.{SCIMConstants.StandardSCIMReferenceProperties.Value}";
-            var childrenIds = scimRepresentation.FlatAttributes.Where(f => f.FullPath == fullPath).Select(f => f.ValueString);
-            foreach (var propagatedChildren in _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(childrenIds, scimRepresentation.Id, targetAttributeId.Id, sourceRepresentationId: sourceRepresentationId))
-                yield return propagatedChildren;
-
-            foreach (var child in allChildren.Where(c => childrenIds.Contains(c.Id)))
+            var childrenIds = scimRepresentation.FlatAttributes.Where(f => f.FullPath == fullPath).Select(f => f.ValueString).ToList();
+            var children = new List<List<SCIMRepresentationAttribute>>
             {
-                foreach (var strLst in ResolvePropagatedChildren(sourceRepresentationId, child, selfReferenceAttribute, targetAttributeId, allChildren))
-                    yield return strLst;
+                await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(childrenIds, scimRepresentation.Id, targetAttributeId.Id, sourceRepresentationId: sourceRepresentationId)
+            };
+
+            foreach (var child in allChildren.Where(c => childrenIds.Contains(c.Id))) {
+                children.AddRange(await ResolvePropagatedChildren(sourceRepresentationId, child, selfReferenceAttribute, targetAttributeId, allChildren));
             }
+
+            return children;
         }
 
         protected class RepresentationModified

--- a/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationReferenceSync.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationReferenceSync.cs
@@ -95,7 +95,8 @@ namespace SimpleIdServer.Scim.Helpers
                             var fa = rep.FlatAttributes.SingleOrDefault(a => a.SchemaAttributeId == targetAttributeValue.Id && a.ValueString == newSourceScimRepresentation.Id);
                             if(fa == null)
                                 result.AddReferenceAttributes(BuildScimRepresentationAttribute(rep.Id, attributeMapping.TargetAttributeId, newSourceScimRepresentation, mode, newSourceScimRepresentation.ResourceType, targetSchema));
-                            else {
+                            else 
+                            {
                                 var type = rep.FlatAttributes.Single(a => a.SchemaAttributeId == targetAttributeType.Id && a.ParentAttributeId == fa.ParentAttributeId);
                                 if(type.ValueString != "direct")
                                 {
@@ -180,7 +181,8 @@ namespace SimpleIdServer.Scim.Helpers
                             else
                             {
                                 var typeAttr = rep.FlatAttributes.Single(a => a.SchemaAttributeId == targetAttributeType.Id && a.ParentAttributeId == attr.ParentAttributeId);
-                                if(typeAttr.ValueString != "direct") {
+                                if(typeAttr.ValueString != "direct") 
+                                {
                                     typeAttr.ValueString = "direct";
                                     result.UpdateReferenceAttributes(new List<SCIMRepresentationAttribute> { typeAttr });
                                 }
@@ -335,7 +337,8 @@ namespace SimpleIdServer.Scim.Helpers
                                     foreach (var pa in parentAttrs)
                                     {
                                         var subAttrs = children.Where(c => c.ParentAttributeId == pa.Id).ToList();
-                                        if (subAttrs.Any(a => a.SchemaAttributeId == valueAttr.Id && notRemovedChldIds.Contains(a.ValueString))) {
+                                        if (subAttrs.Any(a => a.SchemaAttributeId == valueAttr.Id && notRemovedChldIds.Contains(a.ValueString))) 
+                                        {
                                             atLeastOneParent = true;
                                             break;
                                         }
@@ -421,7 +424,8 @@ namespace SimpleIdServer.Scim.Helpers
                 await _scimRepresentationCommandRepository.FindPaginatedGraphAttributes(childrenIds, scimRepresentation.Id, targetAttributeId.Id, sourceRepresentationId: sourceRepresentationId)
             };
 
-            foreach (var child in allChildren.Where(c => childrenIds.Contains(c.Id))) {
+            foreach (var child in allChildren.Where(c => childrenIds.Contains(c.Id))) 
+            {
                 children.AddRange(await ResolvePropagatedChildren(sourceRepresentationId, child, selfReferenceAttribute, targetAttributeId, allChildren));
             }
 

--- a/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationSyncResult.cs
+++ b/src/Scim/SimpleIdServer.Scim/Helpers/RepresentationSyncResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using SimpleIdServer.Scim.Domains;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SimpleIdServer.Scim.Helpers
 {
@@ -15,6 +16,16 @@ namespace SimpleIdServer.Scim.Helpers
 
         public void RemoveReferenceAttributes(IEnumerable<SCIMRepresentationAttribute> attrs) => RemovedRepresentationAttributes.AddRange(attrs);
 
-        public void UpdateReferenceAttributes(IEnumerable<SCIMRepresentationAttribute> attrs) => UpdatedRepresentationAttributes.AddRange(attrs);
+        public void UpdateReferenceAttributes(IEnumerable<SCIMRepresentationAttribute> attrs, IEnumerable<RepresentationSyncResult> result)
+        {
+            var filteredAttrs = attrs.Where(a => CanUpdate(a) && result.All(r => r.CanUpdate(a)));
+            UpdatedRepresentationAttributes.AddRange(filteredAttrs);
+        }
+
+        public bool CanUpdate(SCIMRepresentationAttribute attr)
+        {
+            var allIds = AddedRepresentationAttributes.Select(a => a.Id).Union(RemovedRepresentationAttributes.Select(a => a.Id)).ToList();
+            return !allIds.Contains(attr.Id);
+        }
     }
 }

--- a/src/Scim/SimpleIdServer.Scim/Persistence/Filters/SearchSCIMRepresentationOrders.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/Filters/SearchSCIMRepresentationOrders.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-using Newtonsoft.Json.Converters;
-using System.Text.Json.Serialization;
 
 namespace SimpleIdServer.Persistence.Filters
 {

--- a/src/Scim/SimpleIdServer.Scim/Persistence/ISCIMAttributeMappingQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/ISCIMAttributeMappingQueryRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using SimpleIdServer.Scim.Domains;
 using System.Collections.Generic;
@@ -8,8 +8,8 @@ namespace SimpleIdServer.Scim.Persistence
 {
     public interface ISCIMAttributeMappingQueryRepository
     {
-        Task<IEnumerable<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes);
-        Task<IEnumerable<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType);
-        Task<IEnumerable<SCIMAttributeMapping>> GetAll();
+        Task<List<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes);
+        Task<List<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType);
+        Task<List<SCIMAttributeMapping>> GetAll();
     }
 }

--- a/src/Scim/SimpleIdServer.Scim/Persistence/ISCIMRepresentationCommandRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/ISCIMRepresentationCommandRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using SimpleIdServer.Scim.Domains;
 using System.Collections.Generic;
@@ -8,13 +8,12 @@ namespace SimpleIdServer.Scim.Persistence
 {
     public interface ISCIMRepresentationCommandRepository : ICommandRepository<SCIMRepresentation>
     {
-        Task<IEnumerable<SCIMRepresentation>> FindSCIMRepresentationByIds(IEnumerable<string> representationIds);
-        IEnumerable<IEnumerable<SCIMRepresentation>> FindPaginatedRepresentations(IEnumerable<string> representationIds, string resourceType = null, int nbRecords = 50, bool ignoreAttributes = false);
-        IEnumerable<IEnumerable<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null);
-        IEnumerable<IEnumerable<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(IEnumerable<string> representationIds, string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null);
+        Task<List<SCIMRepresentation>> FindPaginatedRepresentations(List<string> representationIds, string resourceType = null, int nbRecords = 50, bool ignoreAttributes = false);
+        Task<List<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null);
+        Task<List<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(IEnumerable<string> representationIds, string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null);
         Task<SCIMRepresentation> FindSCIMRepresentationByAttribute(string attributeId, string value, string endpoint = null);
         Task<SCIMRepresentation> FindSCIMRepresentationByAttribute(string attributeId, int value, string endpoint = null);
-        Task<IEnumerable<SCIMRepresentation>> FindSCIMRepresentationsByAttributeFullPath(string fullPath, IEnumerable<string> values, string resourceType);
+        Task<List<SCIMRepresentation>> FindSCIMRepresentationsByAttributeFullPath(string fullPath, IEnumerable<string> values, string resourceType);
         Task BulkInsert(IEnumerable<SCIMRepresentationAttribute> scimRepresentationAttributes);
         Task BulkDelete(IEnumerable<SCIMRepresentationAttribute> scimRepresentationAttributes);
         Task BulkUpdate(IEnumerable<SCIMRepresentationAttribute> scimRepresentationAttributes);

--- a/src/Scim/SimpleIdServer.Scim/Persistence/ITransaction.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/ITransaction.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace SimpleIdServer.Scim.Persistence
 {
-    public interface ITransaction : IDisposable
+    public interface ITransaction : IDisposable, IAsyncDisposable
     {
         Task Commit(CancellationToken token = default(CancellationToken));
     }

--- a/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultAttributeMappingQueryRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultAttributeMappingQueryRepository.cs
@@ -16,20 +16,20 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
             _attributeMappingLst = attributeMappingLst;
         }
 
-        public Task<IEnumerable<SCIMAttributeMapping>> GetAll()
+        public Task<List<SCIMAttributeMapping>> GetAll()
         {
-            IEnumerable<SCIMAttributeMapping> result = _attributeMappingLst;
+            var result = _attributeMappingLst;
             return Task.FromResult(result);
         }
 
-        public Task<IEnumerable<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes)
+        public Task<List<SCIMAttributeMapping>> GetBySourceAttributes(IEnumerable<string> sourceAttributes)
         {
-            return Task.FromResult(_attributeMappingLst.Where(a => sourceAttributes.Contains(a.SourceAttributeSelector)));
+            return Task.FromResult(_attributeMappingLst.Where(a => sourceAttributes.Contains(a.SourceAttributeSelector)).ToList());
         }
 
-        public Task<IEnumerable<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType)
+        public Task<List<SCIMAttributeMapping>> GetBySourceResourceType(string sourceResourceType)
         {
-            return Task.FromResult(_attributeMappingLst.Where(a => a.SourceResourceType == sourceResourceType));
+            return Task.FromResult(_attributeMappingLst.Where(a => a.SourceResourceType == sourceResourceType).ToList());
         }
     }
 }

--- a/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultSCIMRepresentationCommandRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultSCIMRepresentationCommandRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 using SimpleIdServer.Scim.Domains;
 using System;
@@ -12,28 +12,12 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
     public class DefaultSCIMRepresentationCommandRepository : InMemoryCommandRepository<SCIMRepresentation>, ISCIMRepresentationCommandRepository
     {
         public DefaultSCIMRepresentationCommandRepository(List<SCIMRepresentation> lstData) : base(lstData) { }
-
-        public Task<IEnumerable<SCIMRepresentation>> FindSCIMRepresentationByIds(IEnumerable<string> representationIds)
-        {
-            IEnumerable<SCIMRepresentation> representations = LstData.AsQueryable().Where(r => representationIds.Contains(r.Id));
-            return Task.FromResult(representations);
+        
+        public Task<List<SCIMRepresentation>> FindPaginatedRepresentations(List<string> representationIds, string resourceType = null, int nbRecords = 50, bool ignoreAttributes = false) {
+            return Task.FromResult(LstData.Where(r => r.ResourceType == resourceType || string.IsNullOrWhiteSpace(resourceType)).ToList());
         }
 
-        public IEnumerable<IEnumerable<SCIMRepresentation>> FindPaginatedRepresentations(IEnumerable<string> representationIds, string resourceType = null, int nbRecords = 50, bool ignoreAttributes = false)
-        {
-            var nb = representationIds.Count();
-            var nbPages = Math.Ceiling((decimal)(nb / nbRecords));
-            for (var i = 0; i <= nbPages; i++)
-            {
-                var filter = representationIds.Skip(i * nbRecords).Take(nbRecords);
-                var result = LstData.Where(r => filter.Contains(r.Id));
-                if (!string.IsNullOrWhiteSpace(resourceType))
-                    yield return result.Where(r => r.ResourceType == resourceType);
-                else yield return result;
-            }
-        }
-
-        public IEnumerable<IEnumerable<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null)
+        public Task<List<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null)
         {
             var allAttributes = LstData.SelectMany(r => r.FlatAttributes);
             var query = allAttributes
@@ -42,21 +26,25 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
                 .Select(r => r.ParentAttributeId);
             var nb = query.Count();
             var nbPages = Math.Ceiling((decimal)(nb / nbRecords));
+            var results = new List<SCIMRepresentationAttribute>();
             for (var i = 0; i <= nbPages; i++)
             {
                 var parentIds = query.Skip(i * nbRecords).Take(nbRecords);
                 var result = allAttributes
                     .Where(a => parentIds.Contains(a.Id) || parentIds.Contains(a.ParentAttributeId));
-                yield return result;
+                results.AddRange(result);
             }
+            return Task.FromResult(results);
         }
 
 
-        public IEnumerable<IEnumerable<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(IEnumerable<string> representationIds, string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null)
+
+        public Task<List<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(IEnumerable<string> representationIds, string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null)
         {
             var allAttributes = LstData.SelectMany(r => r.FlatAttributes);
             var nb = representationIds.Count();
             var nbPages = Math.Ceiling((decimal)(nb / nbRecords));
+            var results = new List<SCIMRepresentationAttribute>();
             for (var i = 0; i <= nbPages; i++)
             {
                 var filter = representationIds.Skip(i * nbRecords).Take(nbRecords);
@@ -66,8 +54,9 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
                     .ToList();
                 var result = allAttributes
                     .Where(a => parentIds.Contains(a.Id) || parentIds.Contains(a.ParentAttributeId));
-                yield return result;
+                results.AddRange(result);
             }
+            return Task.FromResult(results);
         }
 
         public Task<SCIMRepresentation> FindSCIMRepresentationByAttribute(string attrSchemaId, string value, string endpoint = null)
@@ -92,12 +81,12 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
             return Task.FromResult(result);
         }
 
-        public Task<IEnumerable<SCIMRepresentation>> FindSCIMRepresentationsByAttributeFullPath(string fullPath, IEnumerable<string> values, string resourceType)
+        public Task<List<SCIMRepresentation>> FindSCIMRepresentationsByAttributeFullPath(string fullPath, IEnumerable<string> values, string resourceType)
         {
             var result = LstData.Where(r =>
             {
                 return r.ResourceType == resourceType && r.FlatAttributes.Any(a => a.FullPath == fullPath && values.Contains(a.ValueString));
-            });
+            }).ToList();
             return Task.FromResult(result);
         }
 

--- a/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultSCIMRepresentationCommandRepository.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultSCIMRepresentationCommandRepository.cs
@@ -13,8 +13,11 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
     {
         public DefaultSCIMRepresentationCommandRepository(List<SCIMRepresentation> lstData) : base(lstData) { }
         
-        public Task<List<SCIMRepresentation>> FindPaginatedRepresentations(List<string> representationIds, string resourceType = null, int nbRecords = 50, bool ignoreAttributes = false) {
-            return Task.FromResult(LstData.Where(r => r.ResourceType == resourceType || string.IsNullOrWhiteSpace(resourceType)).ToList());
+        public Task<List<SCIMRepresentation>> FindPaginatedRepresentations(List<string> representationIds, string resourceType = null, int nbRecords = 50, bool ignoreAttributes = false)
+        {
+            var representations = LstData.AsQueryable().Where(r => representationIds.Contains(r.Id));
+            if (!string.IsNullOrWhiteSpace(resourceType)) representations = representations.Where(r => r.ResourceType == resourceType);
+            return Task.FromResult(representations.ToList());
         }
 
         public Task<List<SCIMRepresentationAttribute>> FindPaginatedGraphAttributes(string valueStr, string schemaAttributeId, int nbRecords = 50, string sourceRepresentationId = null)

--- a/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultTransaction.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultTransaction.cs
@@ -18,7 +18,7 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
 
         public ValueTask DisposeAsync()
         {
-            return ValueTask.CompletedTask;
+            return new ValueTask();
         }
     }
 }

--- a/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultTransaction.cs
+++ b/src/Scim/SimpleIdServer.Scim/Persistence/InMemory/DefaultTransaction.cs
@@ -15,5 +15,10 @@ namespace SimpleIdServer.Scim.Persistence.InMemory
         public void Dispose()
         {
         }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/src/Scim/SimpleIdServer.Scim/SimpleIdServer.Scim.csproj
+++ b/src/Scim/SimpleIdServer.Scim/SimpleIdServer.Scim.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>SCIM2.0 implementation.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim/SimpleIdServer.Scim.csproj
+++ b/src/Scim/SimpleIdServer.Scim/SimpleIdServer.Scim.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>SCIM2.0 implementation.</Description>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
     <PackageReference Include="MassTransit" Version="8.*" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
+	<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleIdServer.Scim.Parser\SimpleIdServer.Scim.Parser.csproj" />

--- a/src/Scim/SimpleIdServer.ScimSwaggerV6.Startup/SimpleIdServer.ScimSwaggerV6.Startup.csproj
+++ b/src/Scim/SimpleIdServer.ScimSwaggerV6.Startup/SimpleIdServer.ScimSwaggerV6.Startup.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/FakeStartup.cs
+++ b/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/FakeStartup.cs
@@ -165,6 +165,7 @@ namespace SimpleIdServer.Scim.Host.Acceptance.Tests
                     TargetAttributeId = customUserSchema.Attributes.First(a => a.Name == "entitlements").Id
                 }
             };
+            
             services.AddMvc(o =>
             {
                 o.EnableEndpointRouting = false;

--- a/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/SimpleIdServer.Scim.Host.Acceptance.Tests.csproj
+++ b/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/SimpleIdServer.Scim.Host.Acceptance.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup> 

--- a/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/SimpleIdServer.Scim.Host.Acceptance.Tests.csproj
+++ b/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/SimpleIdServer.Scim.Host.Acceptance.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.3" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
     <PackageReference Include="SpecFlow" Version="3.7.13" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.7.13" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.7.13" />

--- a/tests/SimpleIdServer.Scim.Tests/SimpleIdServer.Scim.Tests.csproj
+++ b/tests/SimpleIdServer.Scim.Tests/SimpleIdServer.Scim.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/SimpleIdServer.Scim.Tests/SimpleIdServer.Scim.Tests.csproj
+++ b/tests/SimpleIdServer.Scim.Tests/SimpleIdServer.Scim.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
In this PR the main changes relate to using async overloads of DB queries.
Using async overloads is considered as the good practice in asp.net, and after a benchmark I conducted, these changes improved the performance by several magnitudes.

Also, the usage of `yield` in DB queries is considered to be less efficient with respect to network.

Another performance improvements introduced in here: 
* The `ResolveChildren` and `ResolveParents` functions, queried the same representations multiple times, so I added a check that makes sure that each representation is queried only once.
* The implementation of GET methods can use the `AsNoTracking` behavior which improves performance.
* I used the paginated variation in a few places that did not use it.