### PR TITLE
Packages upgraded

### DIFF
--- a/src/IdServer/SimpleIdServer.IdServer.Domains/SimpleIdServer.IdServer.Domains.csproj
+++ b/src/IdServer/SimpleIdServer.IdServer.Domains/SimpleIdServer.IdServer.Domains.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.26.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.26.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\SimpleIdServer.IdServer.Helpers\SimpleIdServer.IdServer.Helpers.csproj" />

--- a/src/IdServer/SimpleIdServer.IdServer/Extensions/QueryCollectionExtensions.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Extensions/QueryCollectionExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Http
             {
                 try
                 {
-                    return JsonNode.Parse(strValues.ElementAt(0));
+                    return strValues.ElementAt(0);
                 }
                 catch
                 {

--- a/src/IdServer/SimpleIdServer.IdServer/Extensions/QueryCollectionExtensions.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Extensions/QueryCollectionExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Http
             {
                 try
                 {
-                    return strValues.ElementAt(0);
+                    return JsonNode.Parse(strValues.ElementAt(0));
                 }
                 catch
                 {

--- a/src/IdServer/SimpleIdServer.IdServer/SimpleIdServer.IdServer.csproj
+++ b/src/IdServer/SimpleIdServer.IdServer/SimpleIdServer.IdServer.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="QRCoder" Version="1.4.1" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.14" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="7.0.1" />
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.32" />
 		<PackageReference Include="Hangfire.InMemory" Version="0.3.5" />

--- a/src/Scim/SimpleIdServer.Scim.Domains/SimpleIdServer.Scim.Domains.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Domains/SimpleIdServer.Scim.Domains.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="11.0.*" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="System.Text.Json" Version="6.0.*" />
 	</ItemGroup>
 </Project>

--- a/src/Scim/SimpleIdServer.Scim.MongoDb.Startup/SimpleIdServer.Scim.MongoDb.Startup.csproj
+++ b/src/Scim/SimpleIdServer.Scim.MongoDb.Startup/SimpleIdServer.Scim.MongoDb.Startup.csproj
@@ -4,12 +4,15 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.14" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.14">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.14" />
 	  <PackageReference Include="AspNetCore.Authentication.ApiKey" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.Postgre.Startup/SimpleIdServer.Scim.Postgre.Startup.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Postgre.Startup/SimpleIdServer.Scim.Postgre.Startup.csproj
@@ -4,13 +4,16 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.14" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.14">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.14" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0 " />
   </ItemGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.Startup/SimpleIdServer.Scim.Startup.csproj
+++ b/src/Scim/SimpleIdServer.Scim.Startup/SimpleIdServer.Scim.Startup.csproj
@@ -5,12 +5,12 @@
     <UserSecretsId>92c92b21-9f78-4587-8bf0-62d2c5122c17</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.14" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.14" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0 " />
 	<PackageReference Include="AspNetCore.Authentication.ApiKey" Version="7.0.0" />
   </ItemGroup>

--- a/src/Scim/SimpleIdServer.Scim.SwashbuckleV6/SimpleIdServer.Scim.SwashbuckleV6.csproj
+++ b/src/Scim/SimpleIdServer.Scim.SwashbuckleV6/SimpleIdServer.Scim.SwashbuckleV6.csproj
@@ -7,6 +7,6 @@
     <ProjectReference Include="..\SimpleIdServer.Scim\SimpleIdServer.Scim.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Scim/SimpleIdServer.Scim/SimpleIdServer.Scim.csproj
+++ b/src/Scim/SimpleIdServer.Scim/SimpleIdServer.Scim.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.*" />
 	<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.1" />
 	<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Scim/SimpleIdServer.ScimSwaggerV6.Startup/SimpleIdServer.ScimSwaggerV6.Startup.csproj
+++ b/src/Scim/SimpleIdServer.ScimSwaggerV6.Startup/SimpleIdServer.ScimSwaggerV6.Startup.csproj
@@ -4,11 +4,11 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.14" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0 " />
   </ItemGroup>
   <ItemGroup>

--- a/tests/SimpleIdServer.Configuration.Tests/SimpleIdServer.Configuration.Tests.csproj
+++ b/tests/SimpleIdServer.Configuration.Tests/SimpleIdServer.Configuration.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/tests/SimpleIdServer.DID.Tests/SimpleIdServer.DID.Tests.csproj
+++ b/tests/SimpleIdServer.DID.Tests/SimpleIdServer.DID.Tests.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/tests/SimpleIdServer.IdServer.Tests/SimpleIdServer.IdServer.Tests.csproj
+++ b/tests/SimpleIdServer.IdServer.Tests/SimpleIdServer.IdServer.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/tests/SimpleIdServer.IdServer.U2FClient.Tests/SimpleIdServer.IdServer.U2FClient.Tests.csproj
+++ b/tests/SimpleIdServer.IdServer.U2FClient.Tests/SimpleIdServer.IdServer.U2FClient.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/SimpleIdServer.Scim.Host.Acceptance.Tests.csproj
+++ b/tests/SimpleIdServer.Scim.Host.Acceptance.Tests/SimpleIdServer.Scim.Host.Acceptance.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.3" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.14" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.14" />
     <PackageReference Include="SpecFlow" Version="3.7.13" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.7.13" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.7.13" />

--- a/tests/SimpleIdServer.Vc.Tests/SimpleIdServer.Vc.Tests.csproj
+++ b/tests/SimpleIdServer.Vc.Tests/SimpleIdServer.Vc.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />


### PR DESCRIPTION
Upgraded packages and SCIM project to .net 7 as it was .net 5.  Bought all packages inline with same version as many were out of alignment.  Did a quick test to ensure all was working as expected in terms of login and SCIM menus etc.

This removes most warnings from VS when opening sln.