### PR TITLE
Fix null reference exception upon filter parsing

### DIFF
--- a/src/Scim/SimpleIdServer.Scim.Parser/Expressions/SCIMComplexAttributeExpression.cs
+++ b/src/Scim/SimpleIdServer.Scim.Parser/Expressions/SCIMComplexAttributeExpression.cs
@@ -13,13 +13,17 @@ namespace SimpleIdServer.Scim.Parser.Expressions
             GroupingFilter = groupingFilter;
         }
 
-        public SCIMComplexAttributeExpression(string name, SCIMExpression groupingFilter, SCIMAttributeExpression child) : this(name, child) { }
+        public SCIMComplexAttributeExpression(string name, SCIMExpression groupingFilter, SCIMAttributeExpression child)
+            : this(name, groupingFilter)
+        {
+            Child = child;
+        }
 
         public SCIMExpression GroupingFilter { get; set; }
 
         public override object Clone()
         {
-            return new SCIMComplexAttributeExpression(Name, (SCIMExpression)GroupingFilter.Clone(), (SCIMAttributeExpression)Child.Clone());
+            return new SCIMComplexAttributeExpression(Name, (SCIMExpression)GroupingFilter.Clone(), (SCIMAttributeExpression)Child?.Clone());
         }
 
         protected override ICollection<SCIMRepresentationAttribute> InternalBuildEmptyAttributes()

--- a/tests/SimpleIdServer.Scim.Tests/FilterFixture.cs
+++ b/tests/SimpleIdServer.Scim.Tests/FilterFixture.cs
@@ -143,7 +143,8 @@ namespace SimpleIdServer.Scim.Tests
             var thirtyResult = ParseAndExecuteFilter(representations.AsQueryable(), "urn:ietf:params:scim:schemas:core:2.0:User:name.familyName co \"O'Malley\"", customSchema);
             var twentyTwoResult = ParseAndExecuteFilter(representations.AsQueryable(), "(userName eq \"bjensen\")", customSchema);
             var twentyThreeResult = ParseAndExecuteFilter(representations.AsQueryable(), "(userName eq \"bjensen\" or userName eq \"Jule\")", customSchema);
-
+            var twentyFourResult = ParseAndExecuteFilter(representations.AsQueryable(), "(userName eq \"bjensen\") and emails[type eq \"work\" and value co \"example.org\"] and phoneNumbers[primary eq \"true\"]", customSchema);
+            
             Assert.Equal(1, firstResult.Count());
             Assert.Equal(1, secondResult.Count());
             Assert.Equal(2, thirdResult.Count());
@@ -168,6 +169,7 @@ namespace SimpleIdServer.Scim.Tests
             Assert.Equal(1, thirtyResult.Count());
             Assert.Equal(1, twentyTwoResult.Count());
             Assert.Equal(2, twentyThreeResult.Count());
+            Assert.Equal(1, twentyFourResult.Count());
         }
 
         private IQueryable<SCIMRepresentation> ParseAndExecuteFilter(IQueryable<SCIMRepresentation> representations, string filter, SCIMSchema customSchema)


### PR DESCRIPTION
Hello there!

I've encountered an issue with the filter parser. Namely, it threw a `NullReferenceException` when I tried to parse an expression similar to the following:
`(userName eq "bjensen") and emails[type eq "work" and value co "example.org"] and phoneNumbers[primary eq "true"]`

I tracked the exception down and noticed that the `Clone()` method of the `SCIMComplexAttributeExpression` did not properly clone the object. I fixed it in this PR and added a test case that covers the fix.