### PR TITLE
Fix error(s) running `./idserver.sh clean`

### DIFF
--- a/idserver.sh
+++ b/idserver.sh
@@ -37,7 +37,7 @@ function fetchSubComponent() {
 function clean() {
     fetchSubComponent
 
-    rm "$build_dir" -r -f
+    rm -rf "$build_dir"
 }
 
 function compile() {


### PR DESCRIPTION
Fixes errors:
rm: /Users/nwoolls/src/dotnet/SimpleIdServer/build: is a directory
rm: -r: No such file or directory
rm: -f: No such file or directory