### PR TITLE
Add SimpleIdServer.Scim.Domains project to the SimpleIdServer.IdServer.Host solution because the SimpleIdServer.IdServer.Startup project wasn't compiling

### DIFF
--- a/SimpleIdServer.IdServer.Host.sln
+++ b/SimpleIdServer.IdServer.Host.sln
@@ -133,6 +133,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "01. Scim", "01. Scim", "{0C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleIdServer.Scim.Parser", "src\Scim\SimpleIdServer.Scim.Parser\SimpleIdServer.Scim.Parser.csproj", "{F5753099-E7C0-406F-B48E-87DAF80F88D5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleIdServer.Scim.Domains", "src\Scim\SimpleIdServer.Scim.Domains\SimpleIdServer.Scim.Domains.csproj", "{78FA92C7-C140-4A77-9777-528ED390332D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -351,6 +353,10 @@ Global
 		{F5753099-E7C0-406F-B48E-87DAF80F88D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5753099-E7C0-406F-B48E-87DAF80F88D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5753099-E7C0-406F-B48E-87DAF80F88D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78FA92C7-C140-4A77-9777-528ED390332D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78FA92C7-C140-4A77-9777-528ED390332D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78FA92C7-C140-4A77-9777-528ED390332D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78FA92C7-C140-4A77-9777-528ED390332D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -417,6 +423,7 @@ Global
 		{7098E926-13C8-4085-9CAA-A27EF72F7520} = {4796A22B-91A9-42AF-87CA-F69392696B0A}
 		{0CF45705-7CD6-48B6-B032-D9031BB67F18} = {4796A22B-91A9-42AF-87CA-F69392696B0A}
 		{F5753099-E7C0-406F-B48E-87DAF80F88D5} = {0CF45705-7CD6-48B6-B032-D9031BB67F18}
+		{78FA92C7-C140-4A77-9777-528ED390332D} = {0CF45705-7CD6-48B6-B032-D9031BB67F18}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1FE1E2C8-475E-4592-8609-D331B1D01730}


### PR DESCRIPTION
Hello, I did a fresh clone of the repository and on the master branch, when trying to compile the SimpleIdServer.IdServer.Startup project from the SimpleIdServer.IdServer.Host solution in Visual Studio, I encountered this error:

![compilar 1](https://github.com/user-attachments/assets/5424ff26-13aa-427a-b36a-680c7042c0a3)

Upon reviewing, I found that the SimpleIdServer.Scim.Domains project needed to be added to the solution:

![compilar 2](https://github.com/user-attachments/assets/48e0cab1-5597-4519-ba62-dce7d6fd140e)

![compilar 3](https://github.com/user-attachments/assets/6d9a8935-8df3-44a5-808d-0e9ecf88aa59)

Once the project was added, the SimpleIdServer.IdServer.Startup project compiled successfully:

![compilar 4](https://github.com/user-attachments/assets/299c208a-1897-4dca-8da0-5d35e5f48114)

![compilar 5](https://github.com/user-attachments/assets/b0c7386b-b9a9-4f29-b1d8-365aee332720)

I hope this will be taken into consideration, thank you.
