### PR TITLE
Allows to remove the empty "oth" Parameter Array in the JWKS Endpoint

### DIFF
--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -58,6 +58,7 @@ services:
       SCIMBaseUrl: "https://scim.localhost.com"
       Authority: "https://idserver.localhost.com"
       SCIM__SCIMRepresentationsExtractionJobOptions__SCIMEdp: "https://scim.localhost.com"
+      IgnoreEmptyOthInJwksEntpoint: false
     depends_on:
       - db
       - scim

--- a/src/IdServer/SimpleIdServer.IdServer.Startup/IdentityServerConfiguration.cs
+++ b/src/IdServer/SimpleIdServer.IdServer.Startup/IdentityServerConfiguration.cs
@@ -15,4 +15,11 @@ public class IdentityServerConfiguration
     public bool IsForwardedEnabled { get; set; }
     public bool IsClientCertificateForwarded { get; set; }
     public bool ForceHttps { get; set; }
+
+    /// <summary>
+    /// Indicates whether the empty "oth" attribute should be ignored in the JWKS endpoint.
+    /// This may help resolve the following error in NextAuth.js when decoding the token:<br />
+    /// RSA JWK "oth" (Other Primes Info) Parameter value is not supported.
+    /// </summary>
+    public bool IgnoreEmptyOthInJwksEntpoint { get; set; } = false;
 }

--- a/src/IdServer/SimpleIdServer.IdServer.Startup/Program.cs
+++ b/src/IdServer/SimpleIdServer.IdServer.Startup/Program.cs
@@ -187,6 +187,7 @@ void ConfigureIdServer(IServiceCollection services)
                 cb.SessionCookieName = identityServerConfiguration.SessionCookieNamePrefix;
             cb.Authority = identityServerConfiguration.Authority;
             cb.ScimClientOptions = conf;
+            cb.IgnoreEmptyOthInJwksEntpoint = identityServerConfiguration.IgnoreEmptyOthInJwksEntpoint;
         }, cookie: c =>
         {
             if (!string.IsNullOrWhiteSpace(identityServerConfiguration.AuthCookieNamePrefix))

--- a/src/IdServer/SimpleIdServer.IdServer.Startup/appsettings.json
+++ b/src/IdServer/SimpleIdServer.IdServer.Startup/appsettings.json
@@ -43,9 +43,7 @@
     }
   },
   "Negotiate": {
-    "NegotiateOptionsLite": {
-
-    }
+    "NegotiateOptionsLite": {}
   },
   "SCIM": {
     "SCIMRepresentationsExtractionJobOptions": {
@@ -121,12 +119,11 @@
     "AdminLogin": "admin",
     "AdminPassword": "admin"
   },
-  "IdServerVpOptions": {
-
-  },
+  "IdServerVpOptions": {},
   "UserLockingOptions": {
     "LockTimeInSeconds": "300",
     "MaxLoginAttempts": "5"
   },
-  "JSON_SEEDS_FILE_PATH": "Seed.json"
+  "JSON_SEEDS_FILE_PATH": "Seed.json",
+  "IgnoreEmptyOthInJwksEntpoint": false
 }

--- a/src/IdServer/SimpleIdServer.IdServer/Api/Jwks/JwksRequestHandler.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Api/Jwks/JwksRequestHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using SimpleIdServer.IdServer.Stores;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace SimpleIdServer.IdServer.Api.Jwks
 {
@@ -40,7 +41,14 @@ namespace SimpleIdServer.IdServer.Api.Jwks
             JsonObject ConvertSigningKey(SigningCredentials signingCredentials)
             {
                 var publicJwk = signingCredentials.SerializePublicJWK();
-                return JsonNode.Parse(JsonSerializer.Serialize(publicJwk)).AsObject();
+                var serializerOptions = new JsonSerializerOptions
+                {
+                    Converters =
+                    {
+                        new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+                    }
+                };
+                return JsonNode.Parse(JsonSerializer.Serialize(publicJwk, serializerOptions)).AsObject();
             }
 
             JsonObject ConvertEncryptionKey(EncryptingCredentials encryptingCredentials)

--- a/src/IdServer/SimpleIdServer.IdServer/Api/Jwks/JwksRequestHandler.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Api/Jwks/JwksRequestHandler.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) SimpleIdServer. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using SimpleIdServer.IdServer.Options;
+using SimpleIdServer.IdServer.Serializers;
 using SimpleIdServer.IdServer.Stores;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 
 namespace SimpleIdServer.IdServer.Api.Jwks
 {
@@ -16,10 +18,16 @@ namespace SimpleIdServer.IdServer.Api.Jwks
     public class JwksRequestHandler : IJwksRequestHandler
     {
         private readonly IKeyStore _keyStore;
+        private readonly IdServerHostOptions _idServerOptions;
+        private static readonly JsonSerializerOptions _ignoreEmptyOth = new()
+        {
+            Converters = { new IgnoreEmptyOthJsonConverter() }
+        };
 
-        public JwksRequestHandler(IKeyStore keyStore)
+        public JwksRequestHandler(IKeyStore keyStore, IOptions<IdServerHostOptions> idServerOptions)
         {
             _keyStore = keyStore;
+            _idServerOptions = idServerOptions.Value;
         }
 
         public JwksResult Get(string realm)
@@ -29,7 +37,7 @@ namespace SimpleIdServer.IdServer.Api.Jwks
             var signingKeys = _keyStore.GetAllSigningKeys(realm);
             var encKeys = _keyStore.GetAllEncryptingKeys(realm);
             // JWT signing keys : Public key pairs for signing issued JWTs that are access tokens, ID Tokens etc... Clients can download them to validate the JWTs.
-            foreach(var key in signingKeys)
+            foreach (var key in signingKeys)
                 result.JsonWebKeys.Add(ConvertSigningKey(key));
 
             // JWT encryption keys : Public keys for letting clients encrypt JWTs that are request objects.
@@ -41,14 +49,8 @@ namespace SimpleIdServer.IdServer.Api.Jwks
             JsonObject ConvertSigningKey(SigningCredentials signingCredentials)
             {
                 var publicJwk = signingCredentials.SerializePublicJWK();
-                var serializerOptions = new JsonSerializerOptions
-                {
-                    Converters =
-                    {
-                        new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
-                    }
-                };
-                return JsonNode.Parse(JsonSerializer.Serialize(publicJwk, serializerOptions)).AsObject();
+                JsonSerializerOptions jsonSeedingOptions = _idServerOptions.IgnoreEmptyOthInJwksEntpoint ? _ignoreEmptyOth : null;
+                return JsonNode.Parse(JsonSerializer.Serialize(publicJwk, jsonSeedingOptions)).AsObject();
             }
 
             JsonObject ConvertEncryptionKey(EncryptingCredentials encryptingCredentials)

--- a/src/IdServer/SimpleIdServer.IdServer/Options/IdServerHostOptions.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Options/IdServerHostOptions.cs
@@ -245,6 +245,13 @@ namespace SimpleIdServer.IdServer.Options
                 return $"{RegistrationCookieName}.{realm}";
             return RegistrationCookieName;
         }
+
+        /// <summary>
+        /// Indicates whether the empty "oth" attribute should be ignored in the JWKS endpoint.
+        /// This may help resolve the following error in NextAuth.js when decoding the token:<br />
+        /// RSA JWK "oth" (Other Primes Info) Parameter value is not supported.
+        /// </summary>
+        public bool IgnoreEmptyOthInJwksEntpoint { get; set; } = false;
     }
 
     public class UICulture

--- a/src/IdServer/SimpleIdServer.IdServer/Serializers/IgnoreEmptyOthConverter.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Serializers/IgnoreEmptyOthConverter.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace SimpleIdServer.IdServer.Serializers
+{
+    internal class IgnoreEmptyOthConverter : JsonConverter<JsonWebKey>
+    {
+        public override JsonWebKey Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return JsonSerializer.Deserialize<JsonWebKey>(ref reader, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, JsonWebKey value, JsonSerializerOptions options)
+        {
+            if (value.Oth != null && value.Oth.Count == 0)
+            {
+                var json = JsonSerializer.Serialize(value, options);
+                var jsonObject = JsonNode.Parse(json).AsObject();
+                jsonObject.Remove("oth");
+                jsonObject.WriteTo(writer);
+            }
+            else
+            {
+                JsonSerializer.Serialize(writer, value, options);
+            }
+        }
+    }
+}

--- a/src/IdServer/SimpleIdServer.IdServer/Serializers/IgnoreEmptyOthJsonConverter.cs
+++ b/src/IdServer/SimpleIdServer.IdServer/Serializers/IgnoreEmptyOthJsonConverter.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.IdentityModel.Tokens;
+﻿// Copyright (c) SimpleIdServer. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -6,7 +8,7 @@ using System.Text.Json.Serialization;
 
 namespace SimpleIdServer.IdServer.Serializers
 {
-    internal class IgnoreEmptyOthConverter : JsonConverter<JsonWebKey>
+    public class IgnoreEmptyOthJsonConverter : JsonConverter<JsonWebKey>
     {
         public override JsonWebKey Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
@@ -17,7 +19,8 @@ namespace SimpleIdServer.IdServer.Serializers
         {
             if (value.Oth != null && value.Oth.Count == 0)
             {
-                var json = JsonSerializer.Serialize(value, options);
+                // The "options" parameter should not be passed. If it is, the IgnoreEmptyOthJsonConverter instance must be removed; otherwise, it will cause an infinite loop.
+                var json = JsonSerializer.Serialize(value);
                 var jsonObject = JsonNode.Parse(json).AsObject();
                 jsonObject.Remove("oth");
                 jsonObject.WriteTo(writer);


### PR DESCRIPTION
You can set IgnoreEmptyOthInJwksEntpoint to `true` to remove remove the empty "oth" Parameter Array in the JWKS Endpoint (`false` by default)

 
![Screenshot from 2025-04-06 23 52 10](https://github.com/user-attachments/assets/1228d1fe-4415-46bb-8396-3d810c3c3556)

This helps with the  issue described in point 2 in #863 

![Screenshot from 2025-04-07 01 10 15](https://github.com/user-attachments/assets/631a22e5-072b-4747-a1ef-f895eebbaa01)

Once the IgnoreEmptyOthInJwksEntpoint config is setted to `true` can decode the token succesfully:

![Screenshot from 2025-04-07 01 11 52](https://github.com/user-attachments/assets/c617f5e3-d94b-4a03-8b92-b1125feaa4ce)

Hope it helps.