### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Thanks to its modularity and extensibility, SimpleIdServer can be customized to 
 Install SimpleIdServer templates.
 
 ```
-dotnet new --install SimpleIdServer.Templates
+dotnet new install SimpleIdServer.Templates
 ```
 
 This will add the following templates


### PR DESCRIPTION
Removed dashes in install, as per warning in command line:

```
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.
```