### PR TITLE
SCIM client group search

### DIFF
--- a/src/Scim/SimpleIdServer.Scim.Client/SCIMClient.cs
+++ b/src/Scim/SimpleIdServer.Scim.Client/SCIMClient.cs
@@ -76,7 +76,26 @@ namespace SimpleIdServer.Scim.Client
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"{GetPath(userEdp)}?{queryString}")
             };
-            if(!string.IsNullOrWhiteSpace(accessToken)) request.Headers.Add("Authorization", $"Bearer {accessToken}");
+            if (!string.IsNullOrWhiteSpace(accessToken)) request.Headers.Add("Authorization", accessToken);
+            var httpClient = GetHttpClient();
+            var httpResult = await httpClient.SendAsync(request, cancellationToken);
+            httpResult.EnsureSuccessStatusCode();
+            var json = await httpResult.Content.ReadAsStringAsync(cancellationToken);
+            var jsonObj = JsonObject.Parse(json).AsObject();
+            return (RepresentationSerializer.DeserializeSearchRepresentations(jsonObj), json);
+        }
+
+        public async Task<(SearchResult<RepresentationResult>, string)> SearchGroups(SearchRequest searchRequest, string accessToken, CancellationToken cancellationToken)
+        {
+            if (_resourceTypes == null) await GetResourceTypes(cancellationToken);
+            var groupEdp = _resourceTypes.Resources.Single(r => r.Name == "Group").Endpoint;
+            var queryString = SerializeQueryString(searchRequest);
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri($"{GetPath(groupEdp)}?{queryString}")
+            };
+            if (!string.IsNullOrWhiteSpace(accessToken)) request.Headers.Add("Authorization", accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             httpResult.EnsureSuccessStatusCode();
@@ -94,7 +113,7 @@ namespace SimpleIdServer.Scim.Client
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"{GetPath(groupEdp)}/{id}")
             };
-            if (!string.IsNullOrWhiteSpace(accessToken)) request.Headers.Add("Authorization", $"Bearer {accessToken}");
+            if (!string.IsNullOrWhiteSpace(accessToken)) request.Headers.Add("Authorization", accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             httpResult.EnsureSuccessStatusCode();

--- a/src/Scim/SimpleIdServer.Scim.Client/SCIMClient.cs
+++ b/src/Scim/SimpleIdServer.Scim.Client/SCIMClient.cs
@@ -80,7 +80,7 @@ namespace SimpleIdServer.Scim.Client
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"{GetPath(userEdp)}?{queryString}")
             };
-            if (!string.IsNullOrWhiteSpace(accessToken)) AddAccessTokenToAuthorizationHeader(request, accessToken);
+            if (!string.IsNullOrWhiteSpace(accessToken)) SetAuthorizationHeader(request, accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             httpResult.EnsureSuccessStatusCode();
@@ -99,7 +99,7 @@ namespace SimpleIdServer.Scim.Client
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"{GetPath(groupEdp)}?{queryString}")
             };
-            if (!string.IsNullOrWhiteSpace(accessToken)) AddAccessTokenToAuthorizationHeader(request, accessToken);
+            if (!string.IsNullOrWhiteSpace(accessToken)) SetAuthorizationHeader(request, accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             httpResult.EnsureSuccessStatusCode();
@@ -117,7 +117,7 @@ namespace SimpleIdServer.Scim.Client
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"{GetPath(groupEdp)}/{id}")
             };
-            if (!string.IsNullOrWhiteSpace(accessToken)) AddAccessTokenToAuthorizationHeader(request, accessToken);
+            if (!string.IsNullOrWhiteSpace(accessToken)) SetAuthorizationHeader(request, accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             httpResult.EnsureSuccessStatusCode();
@@ -135,7 +135,7 @@ namespace SimpleIdServer.Scim.Client
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"{GetPath(groupEdp)}/{id}")
             };
-            if (!string.IsNullOrWhiteSpace(accessToken)) AddAccessTokenToAuthorizationHeader(request, accessToken);
+            if (!string.IsNullOrWhiteSpace(accessToken)) SetAuthorizationHeader(request, accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             httpResult.EnsureSuccessStatusCode();
@@ -154,7 +154,7 @@ namespace SimpleIdServer.Scim.Client
                 RequestUri = new Uri(GetPath(userEdp)),
                 Content = new StringContent(jsonObject.ToJsonString(), Encoding.UTF8, "application/json")
             };
-            if (!string.IsNullOrWhiteSpace(accessToken)) AddAccessTokenToAuthorizationHeader(request, accessToken);
+            if (!string.IsNullOrWhiteSpace(accessToken)) SetAuthorizationHeader(request, accessToken);
             var httpClient = GetHttpClient();
             var httpResult = await httpClient.SendAsync(request, cancellationToken);
             if (httpResult.IsSuccessStatusCode) return null;
@@ -162,7 +162,7 @@ namespace SimpleIdServer.Scim.Client
             return JsonSerializer.Deserialize<SCIMErrorRepresentation>(content);
         }
 
-        private void AddAccessTokenToAuthorizationHeader(HttpRequestMessage request, string accessToken)
+        private void SetAuthorizationHeader(HttpRequestMessage request, string accessToken)
         {
             var headerValue = string.IsNullOrEmpty(AuthenticationScheme) 
                 ? accessToken 

--- a/src/Scim/SimpleIdServer.Scim.Client/SearchRequest.cs
+++ b/src/Scim/SimpleIdServer.Scim.Client/SearchRequest.cs
@@ -11,5 +11,7 @@ namespace SimpleIdServer.Scim.Client
         public int Count { get; set; } = 100;
         [JsonPropertyName("startIndex")]
         public int StartIndex { get; set; }
+        [JsonPropertyName("filter")]
+        public string Filter { get; set; }
     }
 }


### PR DESCRIPTION
This PR makes it possible to search for groups with the SCIMClient class from the project SimpleIdServer.Scim.Client.
It also adds the Filter parameter in SearchRequest objects to enable use of filters from the [SCIM specification](https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2).

# Why do I need this?

I have a setup like this:
(My company's application) <--- SimpleIdServer <--- Azure
Users are created/modified on Azure which sends SCIM requests to SimpleIdServer. SimpleIdServer handles SCIM requests and raises events that are handled by an `IntegrationEventConsumer : IConsumer` instance that calls the user management API in my company's application.

My company's application has a Users table in its database, and each user has an attribute "AD name". Users also exist in SimpleIdServer as you know. My IntegrationEventConsumer assumes that a user in my company's application with AD name "AzureAD\john.doe" corresponds to the user in SimpleIdServer that has username "AzureAD\john.doe". So myAppUser.ADName = SidUser.username is how the two user databases are "connected".

When a group is added to SimpleIdServer, the method `Consume(ConsumeContext<RepresentationAddedEvent> context)` is called in my `IntegrationEventConsumer` class. The group data sent to this `Consume`-method has an `IEnumerable<ScimGroupMember>` property. An instance of `ScimGroupMember` only specifies the ID of the user in the SimpleIdServer database, no other attributes (particularly username) are included. I need to know the username of the users in the group, which I use the SCIMClient class for. Once I have obtained the full user objects for the users that are part of the added group, I need to do one more thing. For each user in the group, I want to know of all groups that it belongs to. This is where I noticed that the SCIMClient class was missing the SearchGroups method. Without it I could not get the displayName of all groups that a user is member of.